### PR TITLE
Add an endpoint that generates a PCA overview plot

### DIFF
--- a/devops/metabulo/R/pca.R
+++ b/devops/metabulo/R/pca.R
@@ -1,0 +1,23 @@
+#' Basic PCA plot
+#'
+#' Uses MetaboAnalystR's PlotPCAPairSummary method
+
+pca_overview_plot <- function(table) {
+  library(MetaboAnalystR)
+  # most of this seems to be required to get the PCA and plotting methods to work
+  mSet<-InitDataObjects("conc", "stat", FALSE);
+  mSet<-Read.TextData(mSet, table, "rowu", "disc");
+  mSet<-SanityCheckData(mSet);
+  mSet<-RemoveMissingPercent(mSet, percent=0.5);
+  mSet<-ImputeVar(mSet, method="min");
+  mSet<-PreparePrenormData(mSet);
+  mSet<-Normalization(mSet, "NULL", "NULL", "NULL", ratio=FALSE, ratioNum=20);
+  mSet<-PCA.Anal(mSet);
+
+  pclabels <- paste("PC", 1:5, "\n", round(100*mSet$analSet$pca$variance[1:5],1), "%");
+  if(mSet$dataSet$cls.type == "disc"){
+    pairs(mSet$analSet$pca$x[,1:5], PCH=as.numeric(mSet$dataSet$cls)+1, labels=pclabels);
+  }else{
+    pairs(mSet$analSet$pca$x[,1:5], labels=pclabels);
+  }
+}

--- a/metabulo/opencpu.py
+++ b/metabulo/opencpu.py
@@ -19,6 +19,19 @@ def process_table(uri, table):
     return Response(result.to_csv(), mimetype='text/csv')
 
 
+def generate_image(uri, table, params=None):
+    api_root = current_app.config['OPENCPU_API_ROOT']
+    params = params or {}
+
+    files = {
+        'table': ('table.csv', table.to_csv().encode())
+    }
+    resp = requests.post(api_root + uri + '/png', files=files, params=params)
+    if not resp.ok:
+        return Response(resp.content, status=resp.status_code, mimetype='text/plain')
+    return Response(resp.content, mimetype='image/png')
+
+
 if __name__ == '__main__':
     import sys
     table = pandas.read_csv(sys.argv[2], index_col=0)

--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -2,6 +2,7 @@ from io import BytesIO
 
 from flask import Blueprint, current_app, jsonify, request, Response, send_file
 
+from metabulo import opencpu
 from metabulo.models import CSVFile, CSVFileSchema, db, TableTransform, TableTransformSchema
 from metabulo.plot import make_box_plot
 
@@ -104,3 +105,9 @@ def get_box_plot(csv_id):
     table = csv_file.table
     fig = make_box_plot(table)
     return Response(fig, mimetype='image/png')
+
+
+@csv_bp.route('/csv/<uuid:csv_id>/pca-overview', methods=['GET'])
+def get_pca_overview(csv_id):
+    csv_file = CSVFile.query.get_or_404(csv_id)
+    return opencpu.generate_image('/metabulo/R/pca_overview_plot', csv_file.table)


### PR DESCRIPTION
This is almost certainly not what we want to do, but I'm adding it in service of doing something non-trivial with opencpu.

This takes 2.5 seconds to return the image, but there is a lot of overhead in the implementation.  Since I don't really know R, I had to run it through the full metaboanalyst pipeline, which writes all kinds of files out to disk for the web server.  I think it would be much faster as a simple in-memory implementation (read csv -> PCA -> scatter plot -> return png).