### PR TITLE
Remove drop row/column transforms

### DIFF
--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -85,8 +85,8 @@ class CSVFile(db.Model):
         schema = TableTransformSchema()
         return schema.load(data)
 
-    def save_table(self):
-        return self._save_csv_file_data(self.uri, self.table.to_csv())
+    def save_table(self, table):
+        return self._save_csv_file_data(self.uri, table.to_csv())
 
     @classmethod
     def create_csv_file(cls, id, name, table, meta=None):

--- a/metabulo/transform.py
+++ b/metabulo/transform.py
@@ -65,24 +65,6 @@ class SetValueSchema(BaseSchema, RowMixin, ColumnMixin):
     value = fields.Float(required=True)
 
 
-def drop_row(table, row):
-    table.drop(row, inplace=True)
-    return table
-
-
-class DropRowSchema(BaseSchema, RowMixin):
-    pass
-
-
-def drop_column(table, column):
-    table.drop(column, axis=1, inplace=True)
-    return table
-
-
-class DropColumnSchema(BaseSchema, ColumnMixin):
-    pass
-
-
 def normalize(table):
     for column in table:
         if str(table[column].dtype) != 'object':
@@ -113,8 +95,6 @@ def fill_missing_values_by_mean(table):
 
 registry = {
     'set_value': (set_value, SetValueSchema()),
-    'drop_row': (drop_row, DropRowSchema()),
-    'drop_column': (drop_column, DropColumnSchema()),
     'normalize': (normalize, NormalizeSchema()),
     'fill_missing_values_by_constant': (
         fill_missing_values_by_constant, FillMissingValuesByConstantSchema()),

--- a/tests/test_transform_api.py
+++ b/tests/test_transform_api.py
@@ -24,8 +24,7 @@ def test_post_transform(client, csv_file):
 
 def test_delete_transform(client, csv_file):
     t1 = csv_file.generate_transform({
-        'transform_type': 'drop_row',
-        'row': 'row1',
+        'transform_type': 'normalize',
         'priority': 1
     })
     db.session.add(t1)


### PR DESCRIPTION
In preparation for storing columns and rows in the database, transforms
will no longer be allowed to change the shape or headings of the tables.
These operations will be moved to the prior "ingestion" stage of the
workflow and stored as masked flags in the row/column tables.