### PR TITLE
Implement column and row models for csv files

### DIFF
--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -7,6 +7,7 @@ from flask import current_app
 from flask_sqlalchemy import SQLAlchemy
 from marshmallow import fields, post_dump, post_load, Schema, validate
 from marshmallow.exceptions import ValidationError
+import numpy as np
 import pandas
 from sqlalchemy import MetaData
 from sqlalchemy.schema import UniqueConstraint
@@ -24,20 +25,24 @@ metadata = MetaData(naming_convention={
     'fk': 'fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s',
     'ix': 'ix_%(table_name)s_%(column_0_name)s',
     'uq': 'uq_%(table_name)s_%(column_0_name)s',
-    'ck': 'ck_%(table_name)s_%(constraint_name)s',
+    'ck': 'ck_%(table_name)s_%(column_0_name)s',
 })
 db = SQLAlchemy(metadata=metadata)
+
+TABLE_COLUMN_TYPES = ['primary-id', 'secondary-id', 'numeric', 'qualitative']
+TABLE_ROW_TYPES = ['header', 'sample', 'other']
 
 
 class BaseSchema(Schema):
     __model__ = None
 
     id = fields.UUID(missing=uuid4)
-    created = fields.DateTime(dump_only=True)
 
     @post_load
     def make_object(self, data):
-        return self.__model__(**data)
+        if self.__model__ is not None:
+            return self.__model__(**data)
+        return data
 
 
 class CSVFile(db.Model):
@@ -48,7 +53,9 @@ class CSVFile(db.Model):
 
     @property
     def raw_table(self):
-        return pandas.read_csv(self.uri, index_col=0)
+        if not hasattr(self, '_raw_table'):
+            self._raw_table = pandas.read_csv(self.uri, index_col=0)
+        return self._raw_table.copy()
 
     @property
     def table(self):
@@ -86,13 +93,83 @@ class CSVFile(db.Model):
         return schema.load(data)
 
     def save_table(self, table):
+        if hasattr(self, '_raw_table'):
+            del self._raw_table
         return self._save_csv_file_data(self.uri, table.to_csv())
+
+    def _generate_table_columns(self):
+        table_column_schema = TableColumnSchema()
+        table = self.raw_table
+
+        index = 0
+        columns = []
+        if table.index.name is not None:
+            columns.append(
+                table_column_schema.load({
+                    'csv_file_id': self.id,
+                    'column_header': table.index.name,
+                    'column_index': 0,
+                    'column_type': 'primary-id',
+                    'column_mask': None
+                })
+            )
+            index += 1
+        for column_header, dtype in table.dtypes.items():
+            if dtype == np.object:
+                column_type = 'qualitative'
+            else:
+                column_type = 'numeric'
+
+            columns.append(
+                table_column_schema.load({
+                    'csv_file_id': self.id,
+                    'column_header': column_header,
+                    'column_index': index,
+                    'column_type': column_type,
+                    'column_mask': False
+                })
+            )
+            index += 1
+        return columns
+
+    def _generate_table_rows(self):
+        table_row_schema = TableRowSchema()
+        table = self.raw_table
+
+        # Assuming the first row contains the header for the table.  Removing this assumption
+        # would probably mean reading the table by something other than pandas.read_csv.
+        rows = [
+            table_row_schema.load({
+                'csv_file_id': self.id,
+                'row_id': '',  # or null?
+                'row_index': 0,
+                'row_type': 'header',
+                'row_mask': None
+            })
+        ]
+
+        # Assume all other rows are samples.  There may be other heuristics
+        # to apply here in the future.  Or maybe mask rows with too many
+        # NaN's.
+        for index, row_id in enumerate(table.index):
+            rows.append(
+                table_row_schema.load({
+                    'csv_file_id': self.id,
+                    'row_id': row_id,
+                    'row_index': index + 1,
+                    'row_type': 'sample',
+                    'row_mask': False
+                })
+            )
+        return rows
 
     @classmethod
     def create_csv_file(cls, id, name, table, meta=None):
         csv_file = cls(id=id, name=name, meta=meta)
         cls._save_csv_file_data(csv_file.uri, table)
-        return csv_file
+        rows = csv_file._generate_table_rows()
+        columns = csv_file._generate_table_columns()
+        return csv_file, rows, columns
 
     @classmethod
     def _save_csv_file_data(cls, uri, table_data):
@@ -115,25 +192,15 @@ def _validate_name(name):
 
 
 class CSVFileSchema(BaseSchema):
-    __model__ = CSVFile.create_csv_file
-
+    created = fields.DateTime(dump_only=True)
     name = fields.Str(required=True, validate=_validate_name)
     table = fields.Raw(required=True, validate=_validate_table_data)
     meta = fields.Dict(missing=dict)
 
+    columns = fields.List(fields.Nested('TableColumnSchema', exclude=['csv_file']))
+    rows = fields.List(fields.Nested('TableRowSchema', exclude=['csv_file']))
     transforms = fields.List(
         fields.Nested('TableTransformSchema', exclude=['csv_file']), dump_only=True)
-
-    @post_dump
-    def generate_columns(self, data):
-        columns = []
-        for name, type in data['table'].dtypes.items():
-            columns.append({
-                'name': name,
-                'type': str(type)
-            })
-        data['columns'] = columns
-        return data
 
     @post_load
     def fix_file_name(self, data):
@@ -144,6 +211,72 @@ class CSVFileSchema(BaseSchema):
     def read_csv_file(self, data):
         data['table'] = data['table'].to_csv()
         return data
+
+    @post_load
+    def make_object(self, data):
+        csv_file, rows, columns = CSVFile.create_csv_file(**data)
+        db.session.add(csv_file)
+        db.session.add_all(rows + columns)
+        return csv_file
+
+
+class TableColumn(db.Model):
+    __table_args__ = (
+        UniqueConstraint('column_header', 'csv_file_id'),
+        UniqueConstraint('column_index', 'csv_file_id')
+    )
+
+    id = db.Column(UUIDType(binary=False), primary_key=True, default=uuid4)
+    csv_file_id = db.Column(UUIDType(binary=False), db.ForeignKey('csv_file.id'), nullable=False)
+    column_header = db.Column(db.String, nullable=False)
+    column_index = db.Column(db.Integer, nullable=False)
+    column_type = db.Column(db.String, nullable=False)
+    column_mask = db.Column(db.Boolean, nullable=True)
+
+    csv_file = db.relationship(CSVFile, backref=db.backref('columns', lazy=True))
+
+
+class TableColumnSchema(BaseSchema):
+    __model__ = TableColumn
+
+    csv_file_id = fields.UUID(required=True, load_only=True)
+    column_header = fields.Str(required=True, nullable=False)
+    column_index = fields.Int(required=True, validate=validate.Range(min=0))
+    column_type = fields.Str(required=True, validate=validate.OneOf(TABLE_COLUMN_TYPES))
+    column_mask = fields.Bool(required=True, allow_none=True)
+
+    csv_file = fields.Nested(
+        CSVFileSchema, exclude=['rows', 'columns', 'transforms'], dump_only=True)
+
+
+class TableRow(db.Model):
+    __table_args__ = (
+        UniqueConstraint('row_id', 'csv_file_id'),
+        UniqueConstraint('row_index', 'csv_file_id')
+    )
+
+    id = db.Column(UUIDType(binary=False), primary_key=True, default=uuid4)
+    csv_file_id = db.Column(
+        UUIDType(binary=False), db.ForeignKey('csv_file.id'), nullable=False)
+    row_id = db.Column(db.String, nullable=False)
+    row_index = db.Column(db.Integer, nullable=False)
+    row_type = db.Column(db.String, nullable=False)
+    row_mask = db.Column(db.Boolean, nullable=True)
+
+    csv_file = db.relationship(CSVFile, backref=db.backref('rows', lazy=True))
+
+
+class TableRowSchema(BaseSchema):
+    __model__ = TableRow
+
+    csv_file_id = fields.UUID(required=True, load_only=True)
+    row_id = fields.Str(required=True, nullable=False)
+    row_index = fields.Int(required=True, validate=validate.Range(min=0))
+    row_type = fields.Str(required=True, validate=validate.OneOf(TABLE_ROW_TYPES))
+    row_mask = fields.Bool(required=True, allow_none=True)
+
+    csv_file = fields.Nested(
+        CSVFileSchema, exclude=['rows', 'columns', 'transforms'], dump_only=True)
 
 
 class TableTransform(db.Model):
@@ -171,6 +304,7 @@ class TableTransformSchema(BaseSchema):
     __model__ = TableTransform
 
     csv_file_id = fields.UUID(required=True, load_only=True)
+    created = fields.DateTime(dump_only=True)
     transform_type = fields.Str(required=True, validate=validate.OneOf(transform.registry.keys()))
     args = fields.Dict(missing=dict)
     priority = fields.Float(required=True)

--- a/tests/test_csv_file.py
+++ b/tests/test_csv_file.py
@@ -21,7 +21,7 @@ def test_upload_csv_file(client):
     assert resp.status_code == 201
     assert resp.json['name'] == 'test_file1.csv'
     assert csv_data.strip().startswith('id,col1,col2')
-    assert len(resp.json['columns']) == 2
+    assert len(resp.json['columns']) == 3
 
 
 def test_post_csv_data(client):
@@ -35,7 +35,7 @@ def test_post_csv_data(client):
     assert resp.status_code == 201
     assert resp.json['name'] == 'test_file1.csv'
     assert csv_data.strip().startswith('id,col1,col2')
-    assert len(resp.json['columns']) == 2
+    assert len(resp.json['columns']) == 3
 
 
 def test_download_csv_file(client, csv_file):


### PR DESCRIPTION
This is a simple read-only implementation of #21.  It uses the defaults from pandas to fill in the initial rows/columns.  In a future PR, I will add endpoints to edit these models, but this should hopefully make clear the intent of the tables.