### PR TITLE
Add metadata tables to CSVFile model

### DIFF
--- a/tests/test_transform_api.py
+++ b/tests/test_transform_api.py
@@ -18,7 +18,8 @@ def test_post_transform(client, csv_file):
     resp = client.post(url_for('csv.create_transform', csv_id=str(csv_file.id)), json=data)
     assert resp.status_code == 201
 
-    table = pandas.read_csv(BytesIO(resp.json['csv_file']['table'].encode()), index_col=0)
+    table = pandas.read_csv(
+        BytesIO(resp.json['csv_file']['metabolite_table'].encode()), index_col=0)
     assert table.at['row1', 'col1'] == 100
 
 
@@ -34,4 +35,4 @@ def test_delete_transform(client, csv_file):
         url_for('csv.delete_transform', csv_id=str(csv_file.id), transform_id=str(t1.id))
     )
     assert resp.status_code == 204
-    assert_frame_equal(csv_file.table, csv_file.raw_table)
+    assert_frame_equal(csv_file.table, csv_file.metabolite_table)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -89,4 +89,4 @@ def test_generate_transform(csv_file):
 
     correct = table.copy()
     correct[:] = [[0.0, 0.0], [1.0, 1.0]]
-    assert_frame_equal(csv_file.table, correct)
+    assert_frame_equal(csv_file.metabolite_table, correct)


### PR DESCRIPTION
This adds new properties to the CSVFile model that break the original table into multiple pieces depending on the input from the user.  The new responses contain:

* table:               The raw csv file (lightly normalized by pandas
                       with empty rows removed)
* metabolite_table:    Only the sample rows and metabolite columns
* metabolite_metadata: Only the metadata rows and metabolite columns
* sample_metadata:     Only the sample rows and metadata columns

All tables include the header row and primary key column.

In regards to the `+/- 1` index offsets, this hides it a bit better, but there are certainly cleaner ways of handling it that will be necessary if we drop some the assumptions on the input tables.