### PR TITLE
Move R package dependencies to a base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ jobs:
           working_directory: ./devops
           name: Build and push Docker image
           command: |
-            docker build -t dozturk2/metabulo:latest .
+            docker build -t metabulo/opencpu:latest .
             echo $DOCKERHUB_PASS | docker login -u $DOCKERHUB_USERNAME --password-stdin
-            docker push dozturk2/metabulo:latest
+            docker push metabulo/opencpu:latest
 
 workflows:
   version: 2

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -1,35 +1,4 @@
-FROM opencpu/rstudio
-
-RUN apt-get update && apt-get install -y \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libxml2-dev
-
-# https://askubuntu.com/questions/921207/installing-package-containing-glib-h
-RUN dpkg -r --force-all libglib2.0-0 && \
-    apt install -f -y && \
-    apt install libglib2.0-0 -y && \
-    apt install libglib2.0-dev -y
-
-RUN apt-get install libcairo2-dev libxt-dev -y
-
-RUN R -e 'install.packages("XML");' && \
-    R -e 'install.packages("plotly");' && \
-    R -e 'install.packages("BiocManager");' && \
-    R -e 'BiocManager::install("genefilter", version = "3.8")' && \
-    R -e 'BiocManager::install("GlobalAncova", version = "3.8")' && \
-    R -e 'BiocManager::install("impute", version = "3.8")' && \
-    R -e 'BiocManager::install("KEGGgraph", version = "3.8")' && \
-    R -e 'BiocManager::install("limma", version = "3.8")' && \
-    R -e 'BiocManager::install("pcaMethods", version = "3.8")' && \
-    R -e 'BiocManager::install("preprocessCore", version = "3.8")' && \
-    R -e 'BiocManager::install("Rgraphviz", version = "3.8")' && \
-    R -e 'BiocManager::install("siggenes", version = "3.8")' && \
-    R -e 'BiocManager::install("SSPA", version = "3.8")' && \
-    R -e 'BiocManager::install("sva", version = "3.8")'
-
-RUN R -e 'install.packages("devtools"); library(devtools); devtools::install_github("xia-lab/MetaboAnalystR")'
-RUN R -e 'library(devtools); devtools::install_github("klutometis/roxygen")'
+FROM metabulo/opencpu-base
 
 ADD metabulo /metabulo
 RUN R -e 'library(devtools); library(roxygen2); setwd("/metabulo"); document(); setwd("/"); install("metabulo")'

--- a/devops/base_image/Dockerfile
+++ b/devops/base_image/Dockerfile
@@ -1,0 +1,32 @@
+FROM opencpu/rstudio
+
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libxml2-dev
+
+# https://askubuntu.com/questions/921207/installing-package-containing-glib-h
+RUN dpkg -r --force-all libglib2.0-0 && \
+    apt install -f -y && \
+    apt install libglib2.0-0 -y && \
+    apt install libglib2.0-dev -y
+
+RUN apt-get install libcairo2-dev libxt-dev -y
+
+RUN R -e 'install.packages("XML");' && \
+    R -e 'install.packages("plotly");' && \
+    R -e 'install.packages("BiocManager");' && \
+    R -e 'BiocManager::install("genefilter", version = "3.8")' && \
+    R -e 'BiocManager::install("GlobalAncova", version = "3.8")' && \
+    R -e 'BiocManager::install("impute", version = "3.8")' && \
+    R -e 'BiocManager::install("KEGGgraph", version = "3.8")' && \
+    R -e 'BiocManager::install("limma", version = "3.8")' && \
+    R -e 'BiocManager::install("pcaMethods", version = "3.8")' && \
+    R -e 'BiocManager::install("preprocessCore", version = "3.8")' && \
+    R -e 'BiocManager::install("Rgraphviz", version = "3.8")' && \
+    R -e 'BiocManager::install("siggenes", version = "3.8")' && \
+    R -e 'BiocManager::install("SSPA", version = "3.8")' && \
+    R -e 'BiocManager::install("sva", version = "3.8")'
+
+RUN R -e 'install.packages("devtools"); library(devtools); devtools::install_github("xia-lab/MetaboAnalystR")'
+RUN R -e 'library(devtools); devtools::install_github("klutometis/roxygen")'


### PR DESCRIPTION
I don't think there is a need to automate the building of the base image.  The remainder of the docker file is just installing our local R package.  I also created a `metabulo` org for storing our images.

This will hopefully fix our publish CI step.