### PR TITLE
Remove column header/row names from the data model

### DIFF
--- a/tests/test_row_column.py
+++ b/tests/test_row_column.py
@@ -52,7 +52,7 @@ def test_list_rows(client, table):
         url_for('csv.list_rows', csv_id=table.id))
     assert resp.status_code == 200
     assert resp.json == [{
-        'row_name': '',
+        'row_name': 'id',
         'row_index': 0,
         'row_type': 'header'
     }, {


### PR DESCRIPTION
This was inspired by the work in #36.  It makes row_name and
column_header computed properties.  This implementation makes use of
hybrid_properties where possible, which will allow us to keep more of
the logic in the ORM layer.

This does remove the ability to query rows by name or columns by header
at the DB layer, but it shouldn't be a problem because our tables are
relatively small.

To make these properties mutable, I'm looking into using setters:

https://docs.sqlalchemy.org/en/latest/orm/extensions/hybrid.html#defining-setters