### PR TITLE
Allow primary key column and header row to be modified

### DIFF
--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -121,9 +121,9 @@ def modify_column(csv_id, column_index):
     args = modify_column_schema.load(request.json or {})
     for key, value in args.items():
         if key == 'column_type' and value == TABLE_COLUMN_TYPES.INDEX:
-            if csv_file.key_column_index is not None:
-                csv_file.columns[csv_file.key_column_index].column_type = TABLE_COLUMN_TYPES.DATA
-        setattr(column, key, value)
+            csv_file.key_column_index = column_index
+        else:
+            setattr(column, key, value)
     db.session.add(column)
     db.session.add(csv_file)
     db.session.commit()
@@ -153,9 +153,9 @@ def modify_row(csv_id, row_index):
     args = modify_row_schema.load(request.json or {})
     for key, value in args.items():
         if key == 'row_type' and value == TABLE_ROW_TYPES.INDEX:
-            if csv_file.header_row_index is not None:
-                csv_file.rows[csv_file.header_row_index].row_type = TABLE_ROW_TYPES.DATA
-        setattr(row, key, value)
+            csv_file.header_row_index = row_index
+        else:
+            setattr(row, key, value)
     db.session.add(row)
     db.session.add(csv_file)
     db.session.commit()

--- a/tests/test_csv_file.py
+++ b/tests/test_csv_file.py
@@ -1,78 +1,121 @@
-from io import BytesIO
+from metabulo.models import CSVFileSchema, db
 
-from flask import url_for
-
-from metabulo.models import CSVFile
-
-csv_data = """
-id,col1,col2
-row1,0.5,2.0
-row2,1.5,0
-"""
+csv_file_schema = CSVFileSchema()
 
 
-def test_upload_csv_file(client):
-    data = {
-        'file': (BytesIO(csv_data.encode()), 'test_file1.csv')
-    }
-    resp = client.post(
-        url_for('csv.upload_csv_file'), data=data, content_type='multipart/form-data')
-
-    assert resp.status_code == 201
-    assert resp.json['name'] == 'test_file1.csv'
-    assert csv_data.strip().startswith('id,col1,col2')
-    assert len(resp.json['columns']) == 3
+def generate_csv_file(data):
+    csv_file = csv_file_schema.load({
+        'table': data,
+        'name': 'test_csv_file.csv'
+    })
+    db.session.add(csv_file)
+    db.session.commit()
+    return csv_file
 
 
-def test_post_csv_data(client):
-    data = {
-        'name': 'test_file1.csv',
-        'table': csv_data
-    }
-    resp = client.post(
-        url_for('csv.create_csv_file'), json=data)
+def test_no_header(app):
+    with app.test_request_context():
+        csv = generate_csv_file("""
+a,1,2,3
+b,4,5,6
+c,7,8,9
+""")
+        db.session.commit()
 
-    assert resp.status_code == 201
-    assert resp.json['name'] == 'test_file1.csv'
-    assert csv_data.strip().startswith('id,col1,col2')
-    assert len(resp.json['columns']) == 3
+        csv.header_row_index = None
+        db.session.commit()
 
-
-def test_download_csv_file(client, csv_file):
-    resp = client.get(
-        url_for('csv.download_csv_file', csv_id=csv_file.id)
-    )
-
-    assert resp.status_code == 200
-    assert 'text/csv' in resp.headers['Content-Type']
-    assert resp.headers['Content-Disposition'] == f'attachment; filename={csv_file.name}'
+        assert csv.headers == ['col1', 'col2', 'col3', 'col4']
+        assert list(csv.table.columns) == ['col2', 'col3', 'col4']
 
 
-def test_get_csv_file(client, csv_file):
-    resp = client.get(
-        url_for('csv.get_csv_file', csv_id=csv_file.id)
-    )
+def test_no_primary_key(app):
+    with app.test_request_context():
+        csv = generate_csv_file("""
+a,b,c
+1,2,3
+4,5,6
+7,8,9
+""")
+        db.session.commit()
 
-    assert resp.status_code == 200
-    assert 'application/json' in resp.headers['Content-Type']
-    assert resp.json['table'] == csv_file.table.to_csv()
+        csv.key_column_index = None
+        db.session.commit()
 
-
-def test_delete_csv_file(client, csv_file):
-    resp = client.delete(
-        url_for('csv.delete_csv_file', csv_id=csv_file.id)
-    )
-
-    assert resp.status_code == 204
-    assert CSVFile.query.first() is None
+        assert csv.keys == ['row1', 'row2', 'row3', 'row4']
+        assert list(csv.table.index) == ['row2', 'row3', 'row4']
 
 
-def test_post_csv_file_error(client):
-    data = {
-        'file': (b'', 'test_file1.csv')
-    }
-    resp = client.post(
-        url_for('csv.upload_csv_file'), data=data, content_type='multipart/form-data')
+def test_no_header_or_primary_key(app):
+    with app.test_request_context():
+        csv = generate_csv_file("""
+1,2,3
+4,5,6
+7,8,9
+""")
+        db.session.commit()
 
-    assert resp.status_code == 400
-    assert resp.json == {'table': ['No columns to parse from file']}
+        csv.key_column_index = None
+        csv.header_row_index = None
+        db.session.commit()
+
+        assert csv.headers == ['col1', 'col2', 'col3']
+        assert list(csv.table.columns) == ['col1', 'col2', 'col3']
+
+        assert csv.keys == ['row1', 'row2', 'row3']
+        assert list(csv.table.index) == ['row1', 'row2', 'row3']
+
+
+def test_set_primary_key(app):
+    with app.test_request_context():
+        csv = generate_csv_file("""
+c1,--,c2,c3
+10,r1,11,12
+13,r2,14,15
+16,r3,17,18
+""")
+        db.session.commit()
+
+        csv.key_column_index = 1
+        db.session.commit()
+
+        assert csv.keys == ['--', 'r1', 'r2', 'r3']
+        assert list(csv.measurement_table.index) == ['r1', 'r2', 'r3']
+
+
+def test_set_header_row(app):
+    with app.test_request_context():
+        csv = generate_csv_file("""
+r1,10,11,12
+--,c1,c2,c3
+r2,13,14,15
+r3,16,17,18
+""")
+        db.session.commit()
+
+        csv.header_row_index = 1
+        db.session.commit()
+
+        assert csv.headers == ['--', 'c1', 'c2', 'c3']
+        assert list(csv.measurement_table.columns) == ['c1', 'c2', 'c3']
+
+
+def test_set_primary_key_and_header_row(app):
+    with app.test_request_context():
+        csv = generate_csv_file("""
+m1,m2,m3,m4
+m5,--,c1,c2
+m6,r1,14,15
+m7,r2,17,18
+""")
+        db.session.commit()
+
+        csv.header_row_index = 1
+        csv.key_column_index = 1
+        db.session.commit()
+
+        assert csv.headers == ['m5', '--', 'c1', 'c2']
+        assert list(csv.measurement_table.columns) == ['c1', 'c2']
+
+        assert csv.keys == ['m2', '--', 'r1', 'r2']
+        assert list(csv.measurement_table.index) == ['r1', 'r2']

--- a/tests/test_csv_file_api.py
+++ b/tests/test_csv_file_api.py
@@ -1,0 +1,78 @@
+from io import BytesIO
+
+from flask import url_for
+
+from metabulo.models import CSVFile
+
+csv_data = """
+id,col1,col2
+row1,0.5,2.0
+row2,1.5,0
+"""
+
+
+def test_upload_csv_file(client):
+    data = {
+        'file': (BytesIO(csv_data.encode()), 'test_file1.csv')
+    }
+    resp = client.post(
+        url_for('csv.upload_csv_file'), data=data, content_type='multipart/form-data')
+
+    assert resp.status_code == 201
+    assert resp.json['name'] == 'test_file1.csv'
+    assert csv_data.strip().startswith('id,col1,col2')
+    assert len(resp.json['columns']) == 3
+
+
+def test_post_csv_data(client):
+    data = {
+        'name': 'test_file1.csv',
+        'table': csv_data
+    }
+    resp = client.post(
+        url_for('csv.create_csv_file'), json=data)
+
+    assert resp.status_code == 201
+    assert resp.json['name'] == 'test_file1.csv'
+    assert csv_data.strip().startswith('id,col1,col2')
+    assert len(resp.json['columns']) == 3
+
+
+def test_download_csv_file(client, csv_file):
+    resp = client.get(
+        url_for('csv.download_csv_file', csv_id=csv_file.id)
+    )
+
+    assert resp.status_code == 200
+    assert 'text/csv' in resp.headers['Content-Type']
+    assert resp.headers['Content-Disposition'] == f'attachment; filename={csv_file.name}'
+
+
+def test_get_csv_file(client, csv_file):
+    resp = client.get(
+        url_for('csv.get_csv_file', csv_id=csv_file.id)
+    )
+
+    assert resp.status_code == 200
+    assert 'application/json' in resp.headers['Content-Type']
+    assert resp.json['table'] == csv_file.table.to_csv()
+
+
+def test_delete_csv_file(client, csv_file):
+    resp = client.delete(
+        url_for('csv.delete_csv_file', csv_id=csv_file.id)
+    )
+
+    assert resp.status_code == 204
+    assert CSVFile.query.first() is None
+
+
+def test_post_csv_file_error(client):
+    data = {
+        'file': (b'', 'test_file1.csv')
+    }
+    resp = client.post(
+        url_for('csv.upload_csv_file'), data=data, content_type='multipart/form-data')
+
+    assert resp.status_code == 400
+    assert resp.json == {'table': ['No columns to parse from file']}


### PR DESCRIPTION
This provides the missing implementation of the mutations allowed in #48.  Over half of the changes here are test cases to assert correct behavior and some minor reorganization.  I think all reasonable examples of CSV files can be supported by the ingest process now.  If there are examples that don't work, we should add test cases.

There are a number of ways this could break in a multiuser environment, but for now it is a safe assumption that only one user will be interacting with a specific csv file at a time.

Finally, the automatic type checking is no longer done in this code.  That logic has been split into a new function that will be implemented later.