### PR TITLE
Always return the raw table through the rest api

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import dotenv
@@ -7,6 +8,7 @@ from metabulo.app import create_app
 from metabulo.models import CSVFileSchema, db
 
 csv_file_schema = CSVFileSchema()
+pathological_file_path = Path(__file__).parent / 'pathological.csv'
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +47,18 @@ def csv_file(client):
         'table': 'id,col1,col2\nrow1,0.5,2.0\nrow2,1.5,0\n',
         'name': 'test_csv_file.csv'
     })
+    db.session.add(csv_file)
+    db.session.commit()
+    yield csv_file
+
+
+@pytest.fixture
+def pathological_table(client):
+    with open(pathological_file_path) as f:
+        csv_file = csv_file_schema.load({
+            'table': f.read(),
+            'name': 'pathological.csv'
+        })
     db.session.add(csv_file)
     db.session.commit()
     yield csv_file

--- a/tests/pathological.csv
+++ b/tests/pathological.csv
@@ -1,0 +1,13 @@
+This one is just empty,This is a comment,,,,,,
+,Something else,,,,,,
+,Sample,Label,"1,6-Anhydro-beta-D-glucose",1-Methylnicotinamide,2-Aminobutyrate,2-Hydroxyisobutyrate,2-Oxoglutarate
+,,,META1,MET2,META3,META4,META5
+,PIF_178,cachexic,40.85,65.37,18.73,26.05,71.52
+,PIF_087,cachexic,62.18,340.36,24.29,41.68,67.36
+,PIF_090,cachexic,270.43,64.72,12.18,65.37,23.81
+,NETL_005_V1,cachexic,154.47,52.98,172.43,74.44,1199.91
+,PIF_115,cachexic,22.2,73.7,15.64,83.93,33.12
+,PIF_110,cachexic,212.72,31.82,18.36,80.64,47.94
+,,,,,,,
+,NETCR_014_V1,cachexic,31.5,6.82,4.18,12.94,25.03
+,NETCR_014_V2,cachexic,51.42,30.27,7.54,34.81,80.64

--- a/tests/test_csv_file.py
+++ b/tests/test_csv_file.py
@@ -26,7 +26,7 @@ c,7,8,9
         db.session.commit()
 
         assert csv.headers == ['col1', 'col2', 'col3', 'col4']
-        assert list(csv.table.columns) == ['col2', 'col3', 'col4']
+        assert list(csv.indexed_table.columns) == ['col2', 'col3', 'col4']
 
 
 def test_no_primary_key(app):
@@ -43,7 +43,7 @@ a,b,c
         db.session.commit()
 
         assert csv.keys == ['row1', 'row2', 'row3', 'row4']
-        assert list(csv.table.index) == ['row2', 'row3', 'row4']
+        assert list(csv.indexed_table.index) == ['row2', 'row3', 'row4']
 
 
 def test_no_header_or_primary_key(app):
@@ -60,10 +60,10 @@ def test_no_header_or_primary_key(app):
         db.session.commit()
 
         assert csv.headers == ['col1', 'col2', 'col3']
-        assert list(csv.table.columns) == ['col1', 'col2', 'col3']
+        assert list(csv.indexed_table.columns) == ['col1', 'col2', 'col3']
 
         assert csv.keys == ['row1', 'row2', 'row3']
-        assert list(csv.table.index) == ['row1', 'row2', 'row3']
+        assert list(csv.indexed_table.index) == ['row1', 'row2', 'row3']
 
 
 def test_set_primary_key(app):

--- a/tests/test_csv_file_api.py
+++ b/tests/test_csv_file_api.py
@@ -76,3 +76,31 @@ def test_post_csv_file_error(client):
 
     assert resp.status_code == 400
     assert resp.json == {'table': ['No columns to parse from file']}
+
+
+def test_row_order_after_reindexing(client, pathological_table):
+    table = pathological_table
+    resp = client.get(url_for('csv.get_csv_file', csv_id=table.id))
+    assert resp.status_code == 200
+
+    table_from_api = resp.json['table']
+
+    resp = client.put(
+        url_for('csv.modify_column', csv_id=table.id, column_index=1),
+        json={'column_type': 'key'}
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(url_for('csv.get_csv_file', csv_id=table.id))
+    assert resp.status_code == 200
+    assert table_from_api == resp.json['table']
+
+    resp = client.put(
+        url_for('csv.modify_row', csv_id=table.id, row_index=3),
+        json={'row_type': 'header'}
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(url_for('csv.get_csv_file', csv_id=table.id))
+    assert resp.status_code == 200
+    assert table_from_api == resp.json['table']

--- a/tests/test_transform_api.py
+++ b/tests/test_transform_api.py
@@ -24,6 +24,7 @@ def test_post_transform(client, csv_file):
 
 
 def test_delete_transform(client, csv_file):
+    original_table = csv_file.measurement_table.copy()
     t1 = csv_file.generate_transform({
         'transform_type': 'normalize',
         'priority': 1
@@ -35,4 +36,4 @@ def test_delete_transform(client, csv_file):
         url_for('csv.delete_transform', csv_id=str(csv_file.id), transform_id=str(t1.id))
     )
     assert resp.status_code == 204
-    assert_frame_equal(csv_file.table, csv_file.measurement_table)
+    assert_frame_equal(original_table, csv_file.measurement_table)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -70,7 +70,7 @@ def test_dispatch_invalid_argument_error(table):
 
 
 def test_generate_transform(csv_file):
-    table = csv_file.table
+    table = csv_file.indexed_table
     table.at['row1', 'col2'] = nan
     csv_file.save_table(table)
 


### PR DESCRIPTION
The `table` property was really intended for internal use.  This renames properties `raw_table` to `table` and `table` to `indexed_table` on the csv_file model.  As a result, the table returned through the REST API for the cleanup UI will always be the same.

Fixes #54 