### PR TITLE
Allow apt-get update to fail on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           at: /tmp/metabulo
       - run:
           name: Install jq
-          command: sudo apt-get update && sudo apt-get install -y jq
+          command: sudo apt-get update ; sudo apt-get install -y jq
       - run:
           name: Create a virtualenv for deployment
           command: |


### PR DESCRIPTION
This seems to fail a lot and isn't particularly important assuming the package index in the container is up to date.