### PR TITLE
Fix/graphstate

### DIFF
--- a/web/src/components/vis/VisPca.vue
+++ b/web/src/components/vis/VisPca.vue
@@ -78,13 +78,8 @@ export default {
      */
     rawPoints: {
       required: true,
-      validator: (prop) => {
-        if (!prop) {
-          return true;
-        }
-        return typeof prop === 'object'
-            && ['x', 'labels'].every(key => key in prop);
-      },
+      validator: prop => !prop
+          || (typeof prop === 'object' && ['x', 'labels'].every(key => key in prop)),
     },
   },
   watch: {

--- a/web/src/components/vis/VisPca.vue
+++ b/web/src/components/vis/VisPca.vue
@@ -71,17 +71,33 @@ export default {
       type: Number,
       default: 300,
     },
+    /* {{
+     *   x: Array<Array<Number>>,
+     *   labels: Object<string, Array<string>>
+     * }}
+     */
     rawPoints: {
-      type: Object,
       required: true,
+      validator: (prop) => {
+        if (!prop) {
+          return true;
+        }
+        return typeof prop === 'object'
+            && ['x', 'labels'].every(key => key in prop);
+      },
     },
   },
   watch: {
-    rawPoints(newVal) {
-      if (newVal) {
+    rawPoints(newval) {
+      if (newval) {
         this.update();
       }
     },
+  },
+  mounted() {
+    if (this.rawPoints) {
+      this.update();
+    }
   },
   methods: {
     update() {
@@ -158,6 +174,7 @@ export default {
           .duration(duration)
           .call(yAxis);
       }
+
 
       // Draw the data.
       //

--- a/web/src/store/actions.type.js
+++ b/web/src/store/actions.type.js
@@ -1,4 +1,5 @@
 export const CHANGE_AXIS_LABEL = 'change_axis_label';
 export const LOAD_DATASET = 'load_dataset';
+export const LOAD_PLOT = 'load_plot';
 export const MUTEX_TRANSFORM_TABLE = 'mutex_transform_table';
 export const UPLOAD_CSV = 'upload_csv';

--- a/web/src/store/mutations.type.js
+++ b/web/src/store/mutations.type.js
@@ -1,9 +1,6 @@
 export const ADD_SOURCE_DATA = 'add_source_data';
-export const DISABLE_CATEGORY = 'disable_category';
-export const REMOVE_TRANSFORMATION = 'remove_transformation';
+export const REFRESH_PLOT = 'refresh_plot';
 export const SET_AXIS_LABEL = 'set_axis_label';
-export const SET_AXIS_MASK = 'set_axis_mask';
 export const SET_LAST_ERROR = 'set_last_error';
 export const SET_LOADING = 'set_loading';
 export const SET_TRANSFORMATION = 'set_transformation';
-export const SET_TRANSFORM_DATA = 'set_transform';


### PR DESCRIPTION
This PR reduces the amount of work a plot container must do to keep its plot up-to-date, and moves the logic for cached/stale points into vuex.

A component wanting to show a plot will need to have the following for each plot it wants to show.

```javascript
export default {
  computed: {
    pcaData() { return this.$store.getters.plotData(this.dataset_id, 'pca'); },
    pcaValid() { return this.$store.getters.plotValid(this.dataset_id, 'pca'); },
  },
  watch: {
    pcaValid: {
      immediate: true,
      handler(valid) {
        if (valid === false) {
          this.$store.dispatch(LOAD_PLOT, { dataset_id: this.dataset_id, name: 'pca' });
        }
      },
    },
  },
};
```

This is nice because:
* No component has to care which mutations cause the plot to become stale.
* Mutations from other components or parts of the app tree will still cause the proper refresh.
* Plots are only updated when they need to be, not necessarily between route changes or remounts.