### PR TITLE
Add a "group" column type

### DIFF
--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -140,6 +140,8 @@ def modify_column(csv_id, column_index):
     for key, value in args.items():
         if key == 'column_type' and value == TABLE_COLUMN_TYPES.INDEX:
             csv_file.key_column_index = column_index
+        elif key == 'column_type' and value == TABLE_COLUMN_TYPES.GROUP:
+            csv_file.group_column_index = column_index
         else:
             setattr(column, key, value)
     db.session.add(column)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def client(app):
 @pytest.fixture
 def csv_file(client):
     csv_file = csv_file_schema.load({
-        'table': 'id,col1,col2\nrow1,0.5,2.0\nrow2,1.5,0\n',
+        'table': 'id,g,col1,col2\nrow1,g,0.5,2.0\nrow2,g,1.5,0\n',
         'name': 'test_csv_file.csv'
     })
     db.session.add(csv_file)

--- a/tests/test_csv_file.py
+++ b/tests/test_csv_file.py
@@ -97,7 +97,8 @@ r3,16,17,18
         db.session.commit()
 
         assert csv.headers == ['--', 'c1', 'c2', 'c3']
-        assert list(csv.measurement_table.columns) == ['c1', 'c2', 'c3']
+        assert list(csv.groups.columns) == ['c1']
+        assert list(csv.measurement_table.columns) == ['c2', 'c3']
 
 
 def test_set_primary_key_and_header_row(app):

--- a/web/src/components/CleanupTable.vue
+++ b/web/src/components/CleanupTable.vue
@@ -94,7 +94,7 @@ export default {
   height: 100%;
   border-collapse: collapse;
 
-  .key, .metadata, .header {
+  .key, .metadata, .header, .group {
     font-weight: 700;
     color: white;
     text-align: left;
@@ -147,7 +147,7 @@ tr.datarow {
   }
 
   &.header, &.metadata {
-    .key, .metadata {
+    .key, .metadata, .group {
       background-color: lightgray !important;
       font-weight: 300;
       color: black;
@@ -159,7 +159,7 @@ tr.datarow {
       background-color: #546E7A;
     }
 
-    td.metadata {
+    td.metadata,td.group {
       background-color: #9E9E9E;
     }
   }
@@ -172,7 +172,7 @@ tr.datarow {
     &.key {
       background-color: #78909C;
     }
-    &.metadata {
+    &.metadata,&.group {
       background-color: #BDBDBD;
     }
   }

--- a/web/src/utils/constants.js
+++ b/web/src/utils/constants.js
@@ -9,6 +9,7 @@ const rowPrimaryKey = 'header';
 
 const colMenuOptions = [
   'key',
+  'group',
   'metadata',
   'measurement',
   'masked',


### PR DESCRIPTION
@subdavis @jtomeck I added the new type to the cleanup table UI, but it could use some way to distinguish "group" columns from other metadata columns.