### PR TITLE
Add table validation for better error handling

### DIFF
--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -70,6 +70,12 @@ def get_csv_file(csv_id):
     return jsonify(csv_file_schema.dump(csv_file))
 
 
+@csv_bp.route('/csv/<uuid:csv_id>/validation', methods=['GET'])
+def get_csv_file_validation(csv_id):
+    csv_file = CSVFile.query.get_or_404(csv_id)
+    return jsonify(csv_file.table_validation)
+
+
 @csv_bp.route('/csv/<uuid:csv_id>/download', methods=['GET'])
 def download_csv_file(csv_id):
     csv_file = CSVFile.query.get_or_404(csv_id)

--- a/tests/test_csv_file.py
+++ b/tests/test_csv_file.py
@@ -69,14 +69,14 @@ def test_no_header_or_primary_key(app):
 def test_set_primary_key(app):
     with app.test_request_context():
         csv = generate_csv_file("""
-c1,--,c2,c3
-10,r1,11,12
-13,r2,14,15
-16,r3,17,18
+c1,g,--,c2,c3
+10,a,r1,11,12
+13,a,r2,14,15
+16,b,r3,17,18
 """)
         db.session.commit()
 
-        csv.key_column_index = 1
+        csv.key_column_index = 2
         db.session.commit()
 
         assert csv.keys == ['--', 'r1', 'r2', 'r3']
@@ -104,18 +104,18 @@ r3,16,17,18
 def test_set_primary_key_and_header_row(app):
     with app.test_request_context():
         csv = generate_csv_file("""
-m1,m2,m3,m4
-m5,--,c1,c2
-m6,r1,14,15
-m7,r2,17,18
+m1,a,m2,m3,m4
+m5,g,--,c1,c2
+m6,a,r1,14,15
+m7,b,r2,17,18
 """)
         db.session.commit()
 
         csv.header_row_index = 1
-        csv.key_column_index = 1
+        csv.key_column_index = 2
         db.session.commit()
 
-        assert csv.headers == ['m5', '--', 'c1', 'c2']
+        assert csv.headers == ['m5', 'g', '--', 'c1', 'c2']
         assert list(csv.measurement_table.columns) == ['c1', 'c2']
 
         assert csv.keys == ['m2', '--', 'r1', 'r2']

--- a/tests/test_csv_file_api.py
+++ b/tests/test_csv_file_api.py
@@ -104,3 +104,23 @@ def test_row_order_after_reindexing(client, pathological_table):
     resp = client.get(url_for('csv.get_csv_file', csv_id=table.id))
     assert resp.status_code == 200
     assert table_from_api == resp.json['table']
+
+
+def test_get_csv_file_validation(client, csv_file):
+    resp = client.get(
+        url_for('csv.get_csv_file_validation', csv_id=csv_file.id)
+    )
+    assert resp.json is None
+
+    resp = client.put(
+        url_for('csv.modify_column', csv_id=csv_file.id, column_index=1),
+        json={
+            'column_type': 'metadata'
+        }
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(
+        url_for('csv.get_csv_file_validation', csv_id=csv_file.id)
+    )
+    assert resp.json == ['No group column']

--- a/tests/test_row_column.py
+++ b/tests/test_row_column.py
@@ -204,9 +204,9 @@ id,g,header1,header2
 
 def test_modify_csv_file_key_index(client):
     table = """
-header1,id,header2,header3,extra
-0,row1,0.5,2.0,
-0,row2,1.5,0,
+header1,group,id,header2,header3,extra
+0,a,row1,0.5,2.0,
+0,b,row2,1.5,0,
 """
     csv_file = csv_file_schema.load({
         'table': table,
@@ -217,13 +217,13 @@ header1,id,header2,header3,extra
 
     csv_id = csv_file.id
     resp = client.put(
-        url_for('csv.modify_column', csv_id=csv_id, column_index=1),
+        url_for('csv.modify_column', csv_id=csv_id, column_index=2),
         json={'column_type': 'key'}
     )
     assert resp.status_code == 200
 
     resp = client.put(
-        url_for('csv.modify_column', csv_id=csv_id, column_index=4),
+        url_for('csv.modify_column', csv_id=csv_id, column_index=5),
         json={'column_type': 'masked'}
     )
     assert resp.status_code == 200


### PR DESCRIPTION
This is an attempt at providing a standard way to communicate the table is not yet ready for transforms.  It adds:
* A `table_validation` property to the `CSVFile` model.  It is a list of problems or `None` if everything is okay.
* A standalone endpoint to get the validation property.

I added the endpoint for a quicker way to get this information after posting row/column type changes.  Alternatively, we could find a way to pass this information in the response to those endpoints.  @subdavis Do you think the new endpoint is sufficient or would it be better to provide this information with all endpoints that are capable of modifying the validation state?