### PR TITLE
Include imputation in the cleanup pipeline

### DIFF
--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -15,6 +15,7 @@ from sqlalchemy_utils.types.json import JSONType
 from sqlalchemy_utils.types.uuid import UUIDType
 from werkzeug.utils import secure_filename
 
+from metabulo.imputation import impute_missing
 from metabulo.normalization import NORMALIZATION_METHODS, normalize
 
 
@@ -273,7 +274,9 @@ class CSVFile(db.Model):
         )
 
     def apply_transforms(self):
-        return normalize(self.normalization, self.raw_measurement_table)
+        table = self.raw_measurement_table
+        table = impute_missing(table, self.groups)
+        return normalize(self.normalization, table)
 
     def save_table(self, table):
         if hasattr(self, '_indexed_table'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 import dotenv
 import pytest
 
+from metabulo import models
 from metabulo.app import create_app
 from metabulo.models import CSVFileSchema, db
 
@@ -17,6 +18,14 @@ def mock_load_dotenv(monkeypatch):
         pass
 
     monkeypatch.setattr(dotenv, 'load_dotenv', do_nothing)
+
+
+@pytest.fixture(autouse=True)
+def mock_imputation(monkeypatch):
+    def noop(table, groups):
+        return table.copy()
+
+    monkeypatch.setattr(models, 'impute_missing', noop)
 
 
 @pytest.fixture


### PR DESCRIPTION
This allows tables with NaN's to work correctly.  It will also test the performance impact of calling out to R.