### PR TITLE
Use dogpile for caching CSV tables

### DIFF
--- a/devops/ansible/site.yml
+++ b/devops/ansible/site.yml
@@ -19,6 +19,7 @@
           - python3-pip
           - nginx
           - sqlite3
+          - memcached
         update_cache: true
       become: true
 
@@ -81,7 +82,7 @@
 
     - name: Install metabulo python package
       pip:
-        name: "/tmp/metabulo-sdist.tar.gz"
+        name: "/tmp/metabulo-sdist.tar.gz[memcached]"
         state: "forcereinstall"
         extra_args: "--no-cache-dir"
         virtualenv: "{{ venv }}"

--- a/devops/ansible/templates/home/gunicorn/.gunicorn_env
+++ b/devops/ansible/templates/home/gunicorn/.gunicorn_env
@@ -7,7 +7,4 @@ export UPLOAD_FOLDER={{ upload_folder }}
 export MAX_FILE_UPLOAD_SIZE=5242880
 
 export OPENCPU_API_ROOT={{ opencpu_api_root }}
-
-
-
-
+export MEMCACHED_URI=127.0.0.1

--- a/metabulo/cache.py
+++ b/metabulo/cache.py
@@ -1,0 +1,36 @@
+from functools import partial
+from hashlib import sha256
+import os
+
+from dogpile.cache import make_region
+from dogpile.cache.util import kwarg_function_key_generator
+from pandas.core.base import PandasObject
+from pandas.util import hash_pandas_object
+
+
+def hash_argument(arg):
+    if isinstance(arg, PandasObject):
+        r = hash_pandas_object(arg, index=True)
+        return sha256(r.values()).hexdigest()
+    return str(arg)
+
+
+region = make_region(
+    'metabulo.app',
+    function_key_generator=partial(kwarg_function_key_generator, to_str=hash_argument)
+)
+
+
+region.configure('dogpile.cache.memory')
+try:
+    # try to configure memcached if possible
+    memcached_uri = os.environ['MEMCACHED_URI']
+    region.configure(
+        'dogpile.cache.pylibmc',
+        arguments={
+            'url': memcached_uri
+        },
+        replace_existing_backend=True
+    )
+except Exception:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=find_packages(include=['metabulo']),
     include_package_data=True,
     install_requires=[
+        'dogpile.cache',
         'flask',
         'flask-sqlalchemy',
         'marshmallow>=3.0.0rc4',
@@ -39,6 +40,9 @@ setup(
         'sqlalchemy-utils',
         'Werkzeug>=0.15'
     ],
+    extras_require={
+        'memcached': ['pylibmc']
+    },
     license='Apache Software License 2.0',
     data_files=data_files,
     entry_points={


### PR DESCRIPTION
This replaces the old method caching (private attributes) with dogpile.
If pylibmc is installed it will use that, otherwise it falls back to an
in-memory cache for development and testing.  This will become more
important when we start adding more caching to the various processing
stages.

I think the deployment changes will work, but maybe not.  Hold my beer.