### PR TITLE
Compute row and column statistics

### DIFF
--- a/metabulo/app.py
+++ b/metabulo/app.py
@@ -5,7 +5,7 @@ from flask import current_app, Flask, jsonify
 from marshmallow import ValidationError
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from metabulo.cache import region
+from metabulo.cache import clear_cache
 from metabulo.models import db
 from metabulo.opencpu import OpenCPUException
 from metabulo.views import csv_bp
@@ -42,18 +42,6 @@ def create_app(config=None):
     app.config['MAX_CONTENT_LENGTH'] = int(os.getenv('MAX_FILE_UPLOAD_SIZE', 5 * 1024 * 1024))
     app.config['OPENCPU_API_ROOT'] = os.getenv('OPENCPU_API_ROOT')
 
-    if 'MEMCACHED_URI' in os.environ and pylibmc:
-        region.configure(
-            'dogpile.cache.pylibmc',
-            arguments={
-                'url': os.environ['MEMCACHED_URI'],
-                'binary': True
-            },
-            replace_existing_backend=True
-        )
-    else:
-        region.configure('dogpile.cache.memory', replace_existing_backend=True)
-
     app.config.update(config)
     db.init_app(app)
 
@@ -63,5 +51,10 @@ def create_app(config=None):
     app.register_error_handler(OpenCPUException, handle_opencpu_error)
     if app.config['ENV'] == 'production':
         app.register_error_handler(500, handle_general_error)
+
+    @app.after_request
+    def clear_cache_after_request(response):
+        clear_cache()
+        return response
 
     return app

--- a/metabulo/cache.py
+++ b/metabulo/cache.py
@@ -7,10 +7,30 @@ from pandas.core.base import PandasObject
 from pandas.util import hash_pandas_object
 
 
+def hash_csv_file(csv_file):
+    """Return a unique checksum for a csv_file model.
+
+    This is designed to be as fast as possible, so it assumes the data
+    contained in the csv is immutable.  The cache needs to be invalidated
+    if the data can change.
+    """
+    # This will need to change if additional pipeline steps are added
+    components = [csv_file.uri, csv_file.normalization or '']
+    components += [r.row_type for r in csv_file.rows]
+    components += [c.column_type for c in csv_file.columns]
+
+    return sha256(''.join(components).encode()).hexdigest()
+
+
 def hash_argument(arg):
+    from metabulo.models import CSVFile  # circular import
+
     if isinstance(arg, PandasObject):
         r = hash_pandas_object(arg, index=True)
-        return sha256(r.values).hexdigest()
+        return sha256(r.values.tostring()).hexdigest()
+    elif isinstance(arg, CSVFile):
+        return hash_csv_file(arg)
+
     return str(arg)
 
 

--- a/metabulo/cache.py
+++ b/metabulo/cache.py
@@ -2,39 +2,42 @@ from functools import partial
 from hashlib import sha256
 
 from dogpile.cache import make_region
+from dogpile.cache.backends.memory import MemoryBackend
 from dogpile.cache.util import kwarg_function_key_generator
+from flask import g
 from pandas.core.base import PandasObject
 from pandas.util import hash_pandas_object
 
 
-def hash_csv_file(csv_file):
-    """Return a unique checksum for a csv_file model.
-
-    This is designed to be as fast as possible, so it assumes the data
-    contained in the csv is immutable.  The cache needs to be invalidated
-    if the data can change.
-    """
-    # This will need to change if additional pipeline steps are added
-    components = [csv_file.uri, csv_file.normalization or '']
-    components += [r.row_type for r in csv_file.rows]
-    components += [c.column_type for c in csv_file.columns]
-
-    return sha256(''.join(components).encode()).hexdigest()
-
-
 def hash_argument(arg):
-    from metabulo.models import CSVFile  # circular import
-
+    from metabulo.models import CSVFile, TableColumn, TableRow
     if isinstance(arg, PandasObject):
         r = hash_pandas_object(arg, index=True)
         return sha256(r.values.tostring()).hexdigest()
-    elif isinstance(arg, CSVFile):
-        return hash_csv_file(arg)
+    elif isinstance(arg, (CSVFile, TableColumn, TableRow)):
+        return str(arg.id)
 
     return str(arg)
+
+
+def clear_cache():
+    g.cache = {}
+
+
+class FlaskRequestLocalBackend(MemoryBackend):
+    """This is a dogpile backend that is local to each request."""
+    def __init__(self, arguments):
+        pass
+
+    @property
+    def _cache(self):
+        if 'cache' not in g:
+            clear_cache()
+        return g.cache
 
 
 region = make_region(
     'metabulo.app',
     function_key_generator=partial(kwarg_function_key_generator, to_str=hash_argument)
-).configure('dogpile.cache.null')
+)
+region.configure('flask_request_local')

--- a/metabulo/cache.py
+++ b/metabulo/cache.py
@@ -14,8 +14,12 @@ def hash_argument(arg):
     if isinstance(arg, PandasObject):
         r = hash_pandas_object(arg, index=True)
         return sha256(r.values.tostring()).hexdigest()
-    elif isinstance(arg, (CSVFile, TableColumn, TableRow)):
+    elif isinstance(arg, CSVFile):
         return str(arg.id)
+    elif isinstance(arg, TableColumn):
+        return str(arg.csv_file_id) + str(arg.column_index)
+    elif isinstance(arg, TableRow):
+        return str(arg.csv_file_id) + str(arg.row_index)
 
     return str(arg)
 

--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -530,9 +530,6 @@ class TableRowSchema(BaseSchema):
     row_type = fields.Str(required=True, validate=validate.OneOf(TABLE_ROW_TYPES))
     data_row_index = fields.Int(dump_only=True, allow_none=True)
 
-    missing_percent = fields.Float(dump_only=True, allow_none=True)
-    data_variance = fields.Float(dump_only=True, allow_none=True)
-
     csv_file = fields.Nested(
         CSVFileSchema, exclude=['rows', 'columns'], dump_only=True)
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
     entry_points={
         'console_scripts': [
             'metabulo-create-tables=metabulo.cli:create_tables'
+        ],
+        'dogpile.cache': [
+            'flask_request_local = metabulo.cache:FlaskRequestLocalBackend'
         ]
     }
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 from metabulo import models
 from metabulo.app import create_app
-from metabulo.cache import region
 from metabulo.models import CSVFileSchema, db
 
 csv_file_schema = CSVFileSchema()
@@ -42,8 +41,6 @@ def app():
         with app.app_context():
             db.create_all()
 
-        # disable cache
-        region.configure('dogpile.cache.null', replace_existing_backend=True)
         yield app
 
 

--- a/tests/test_row_column.py
+++ b/tests/test_row_column.py
@@ -9,7 +9,7 @@ table_data = """
 id,group,meta,col1,col2
 row1,g1,a,0.5,2.0
 row2,g1,b,1.5,0
-row3,g2,b,4,0.5
+row3,g2,b,4,-2.0
 """
 
 
@@ -31,23 +31,38 @@ def test_list_columns(client, table):
     assert resp.json == [{
         'column_header': 'id',
         'column_index': 0,
-        'column_type': 'key'
+        'column_type': 'key',
+        'data_column_index': None,
+        'data_variance': None,
+        'missing_percent': None
     }, {
         'column_header': 'group',
         'column_index': 1,
-        'column_type': 'group'
+        'column_type': 'group',
+        'data_column_index': None,
+        'data_variance': None,
+        'missing_percent': None
     }, {
         'column_header': 'meta',
         'column_index': 2,
-        'column_type': 'measurement'
+        'column_type': 'measurement',
+        'data_column_index': 0,
+        'data_variance': None,
+        'missing_percent': 1.0
     }, {
         'column_header': 'col1',
         'column_index': 3,
-        'column_type': 'measurement'
+        'column_type': 'measurement',
+        'data_column_index': 1,
+        'data_variance': 3.25,
+        'missing_percent': 0.0
     }, {
         'column_header': 'col2',
         'column_index': 4,
-        'column_type': 'measurement'
+        'column_type': 'measurement',
+        'data_column_index': 2,
+        'data_variance': 4.0,
+        'missing_percent': 0.0
     }]
 
 
@@ -58,30 +73,37 @@ def test_list_rows(client, table):
     assert resp.json == [{
         'row_name': 'id',
         'row_index': 0,
-        'row_type': 'header'
+        'row_type': 'header',
+        'data_row_index': None
     }, {
         'row_name': 'row1',
         'row_index': 1,
-        'row_type': 'sample'
+        'row_type': 'sample',
+        'data_row_index': 0
     }, {
         'row_name': 'row2',
         'row_index': 2,
-        'row_type': 'sample'
+        'row_type': 'sample',
+        'data_row_index': 1
     }, {
         'row_name': 'row3',
         'row_index': 3,
-        'row_type': 'sample'
+        'row_type': 'sample',
+        'data_row_index': 2
     }]
 
 
 def test_get_column(client, table):
     resp = client.get(
-        url_for('csv.get_column', csv_id=table.id, column_index=2))
+        url_for('csv.get_column', csv_id=table.id, column_index=3))
     assert resp.status_code == 200
     assert resp.json == {
-        'column_header': 'meta',
-        'column_index': 2,
-        'column_type': 'measurement'
+        'column_header': 'col1',
+        'column_index': 3,
+        'column_type': 'measurement',
+        'data_column_index': 1,
+        'data_variance': 3.25,
+        'missing_percent': 0.0
     }
 
 
@@ -92,7 +114,8 @@ def test_get_row(client, table):
     assert resp.json == {
         'row_name': 'row1',
         'row_index': 1,
-        'row_type': 'sample'
+        'row_type': 'sample',
+        'data_row_index': 0
     }
 
 
@@ -107,7 +130,10 @@ def test_modify_column(client, table):
     assert resp.json == {
         'column_header': 'group',
         'column_index': 1,
-        'column_type': 'metadata'
+        'column_type': 'metadata',
+        'data_column_index': None,
+        'data_variance': None,
+        'missing_percent': None
     }
 
 
@@ -122,7 +148,8 @@ def test_modify_row(client, table):
     assert resp.json == {
         'row_name': 'row1',
         'row_index': 1,
-        'row_type': 'masked'
+        'row_type': 'masked',
+        'data_row_index': None
     }
 
 
@@ -159,7 +186,10 @@ def test_modify_group_column(client, table):
     assert resp.json == {
         'column_header': 'meta',
         'column_index': 2,
-        'column_type': 'group'
+        'column_type': 'group',
+        'data_column_index': None,
+        'data_variance': None,
+        'missing_percent': None
     }
 
     resp = client.get(
@@ -169,7 +199,10 @@ def test_modify_group_column(client, table):
     assert resp.json == {
         'column_header': 'group',
         'column_index': 1,
-        'column_type': 'metadata'
+        'column_type': 'metadata',
+        'data_column_index': None,
+        'data_variance': None,
+        'missing_percent': None
     }
 
 


### PR DESCRIPTION
This adds `missing_percent` and `data_variance` properties on each row and column.  These get returned with the endpoints in case we want to use them in the UI.

I'm marking this as WIP for now because it is far too slow to get merged (adds about 3 seconds to each affected endpoint).  I have some ideas about smarter caching strategies that should help.  If not, I'll have to do some refactoring to reduce the number of duplicate computations occurring.