### PR TITLE
Implement invalid index validation errors

### DIFF
--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -84,7 +84,11 @@ class CSVFile(db.Model):
     def measurement_table(self):
         """Return the processed metabolite date table."""
         if not self.table_validation:
-            return self.apply_transforms()
+            try:
+                return self.apply_transforms()
+            except Exception as e:
+                # TODO: We should handle this better
+                current_app.logger.exception(e)
 
     @property
     def measurement_metadata(self):
@@ -277,13 +281,12 @@ class CSVFileSchema(BaseSchema):
     columns = fields.List(fields.Nested('TableColumnSchema', exclude=['csv_file']))
     rows = fields.List(fields.Nested('TableRowSchema', exclude=['csv_file']))
 
-    table_validation = fields.List(fields.Str, dump_only=True, allow_none=True)
+    table_validation = fields.List(
+        fields.Nested('ValidationSchema'), dump_only=True, allow_none=True)
     measurement_table = fields.Raw(dump_only=True, allow_none=True)
     measurement_metadata = fields.Raw(dump_only=True, allow_none=True)
     sample_metadata = fields.Raw(dump_only=True, allow_none=True)
     groups = fields.Raw(dump_only=True, allow_none=True)
-
-    _stats = fields.Raw(dump_only=True)
 
     @post_load
     def fix_file_name(self, data):

--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -12,12 +12,14 @@ from metabulo.models import CSVFile, CSVFileSchema, db, \
     TableRowSchema
 from metabulo.normalization import NORMALIZATION_METHODS
 from metabulo.plot import pca
+from metabulo.table_validation import ValidationSchema
 
 csv_file_schema = CSVFileSchema()
 modify_column_schema = ModifyColumnSchema()
 modify_row_schema = ModifyRowSchema()
 table_column_schema = TableColumnSchema(exclude=['csv_file'])
 table_row_schema = TableRowSchema(exclude=['csv_file'])
+validation_schema = ValidationSchema()
 
 csv_bp = Blueprint('csv', __name__)
 
@@ -74,7 +76,7 @@ def get_csv_file(csv_id):
 @csv_bp.route('/csv/<uuid:csv_id>/validation', methods=['GET'])
 def get_csv_file_validation(csv_id):
     csv_file = CSVFile.query.get_or_404(csv_id)
-    return jsonify(csv_file.table_validation)
+    return jsonify(validation_schema.dump(csv_file.table_validation, many=True))
 
 
 @csv_bp.route('/csv/<uuid:csv_id>/download', methods=['GET'])


### PR DESCRIPTION
This also fixes a couple of bugs:
1. A temporary fix for 500 errors when the transforms fail
2. Correctly serializes the Validation objects