### PR TITLE
Use memcached for slow functions

### DIFF
--- a/metabulo/cache.py
+++ b/metabulo/cache.py
@@ -8,6 +8,23 @@ from flask import g
 from pandas.core.base import PandasObject
 from pandas.util import hash_pandas_object
 
+_cache_registry = []
+
+
+def csv_file_cache(func):
+    """Cache the results of a function acting on a csv file.
+
+    The purpose of this decorator is to wrap the dogpile decorator, `cache_on_argument`.
+    It keeps a registry of functions that have been decorated and adds the ability
+    to purge the cache for all function calls on a specific model.
+
+    ** This decorator only works with functions taking a single csv_file object as
+    ** an argument.
+    """
+    func = persistent_region.cache_on_arguments()(func)
+    _cache_registry.append(func)
+    return func
+
 
 def hash_argument(arg):
     from metabulo.models import CSVFile, TableColumn, TableRow
@@ -24,8 +41,17 @@ def hash_argument(arg):
     return str(arg)
 
 
-def clear_cache():
+def mangle_key(key):
+    if len(key) <= 256:
+        return key
+    return sha256(key.encode()).hexdigest()
+
+
+def clear_cache(csv_file=None):
     g.cache = {}
+    if csv_file:
+        for func in _cache_registry:
+            func.invalidate(csv_file)
 
 
 class FlaskRequestLocalBackend(MemoryBackend):
@@ -41,7 +67,15 @@ class FlaskRequestLocalBackend(MemoryBackend):
 
 
 region = make_region(
-    'metabulo.app',
+    'metabulo.app.local',
     function_key_generator=partial(kwarg_function_key_generator, to_str=hash_argument)
 )
 region.configure('flask_request_local')
+
+
+persistent_region = make_region(
+    'metabulo.app.persistent',
+    function_key_generator=partial(kwarg_function_key_generator, to_str=hash_argument),
+    key_mangler=mangle_key
+)
+persistent_region.configure('dogpile.cache.null')

--- a/metabulo/normalization.py
+++ b/metabulo/normalization.py
@@ -1,11 +1,11 @@
 from sklearn import preprocessing
 
-from metabulo.cache import region
+from metabulo.cache import persistent_region
 
 NORMALIZATION_METHODS = {'minmax'}
 
 
-@region.cache_on_arguments()
+@persistent_region.cache_on_arguments()
 def normalize(method, table):
     if method is None:
         pass

--- a/metabulo/opencpu.py
+++ b/metabulo/opencpu.py
@@ -4,6 +4,8 @@ from flask import current_app, Response
 import pandas
 import requests
 
+from metabulo.cache import persistent_region
+
 
 class OpenCPUException(Exception):
     def __init__(self, msg, method, response):
@@ -17,6 +19,7 @@ class OpenCPUException(Exception):
                         mimetype='text/plain')
 
 
+@persistent_region.cache_on_arguments()
 def opencpu_request(method, files=None, params=None, return_type='csv'):
     files = files or {}
     params = params or {}

--- a/metabulo/table_validation.py
+++ b/metabulo/table_validation.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from marshmallow import fields, post_dump, Schema, validate
 from pandas import Index
 
-from metabulo.cache import region
+from metabulo.cache import csv_file_cache
 
 SEVERITY_VALUES = ['error', 'warning']
 CONTEXT_VALUES = ['table', 'column', 'row']
@@ -129,7 +129,7 @@ class ValidationSchema(Schema):
         return {k: v for k, v in data.items() if v is not None}
 
 
-@region.cache_on_arguments()
+@csv_file_cache
 def get_validation_list(csv_file):
     errors = get_fatal_index_errors(csv_file)
 
@@ -139,7 +139,7 @@ def get_validation_list(csv_file):
     return errors
 
 
-@region.cache_on_arguments()
+@csv_file_cache
 def get_missing_index_errors(csv_file):
     errors = []
     if csv_file.key_column_index is None:
@@ -151,7 +151,7 @@ def get_missing_index_errors(csv_file):
     return errors
 
 
-@region.cache_on_arguments()
+@csv_file_cache
 def get_fatal_index_errors(csv_file):
     errors = get_missing_index_errors(csv_file)
     if not errors:

--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -214,7 +214,7 @@ def get_pca_plot(csv_id):
             return jsonify({
                 'error': 'OpenCPU call failed',
                 'method': e.method,
-                'response': e.response.content
+                'response': e.response.content.decode()
             }), 502
 
     data = pca(table, max_components)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -36,12 +36,10 @@ def test_normalize_api(client, csv_file):
         url_for('csv.set_normalization_method', csv_id=csv_file.id), json={'method': 'minmax'}
     )
     assert resp.status_code == 200
-    assert resp.json['normalization'] == 'minmax'
-    assert resp.json['measurement_table'] == 'id,col1,col2\nrow1,0.0,1.0\nrow2,1.0,0.0\n'
+    assert resp.json == 'minmax'
 
     resp = client.put(
         url_for('csv.set_normalization_method', csv_id=csv_file.id), json={'method': None}
     )
     assert resp.status_code == 200
-    assert resp.json['normalization'] is None
-    assert resp.json['measurement_table'] == 'id,col1,col2\nrow1,0.5,2.0\nrow2,1.5,0.0\n'
+    assert resp.json is None


### PR DESCRIPTION
This reduces the response time for pca plots on the client by speeding up `GET /csv/:id`, `GET /csv/:id/plot/pca`, and `PUT /csv/:id/normalizaton` by ~10x--making the update when toggling normalization take about 100ms.