### PR TITLE
Disable memcached caching of table validation

### DIFF
--- a/metabulo/cache.py
+++ b/metabulo/cache.py
@@ -42,8 +42,6 @@ def hash_argument(arg):
 
 
 def mangle_key(key):
-    if len(key) <= 256:
-        return key
     return sha256(key.encode()).hexdigest()
 
 

--- a/metabulo/table_validation.py
+++ b/metabulo/table_validation.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from marshmallow import fields, post_dump, Schema, validate
 from pandas import Index
 
-from metabulo.cache import csv_file_cache
+from metabulo.cache import region
 
 SEVERITY_VALUES = ['error', 'warning']
 CONTEXT_VALUES = ['table', 'column', 'row']
@@ -129,7 +129,6 @@ class ValidationSchema(Schema):
         return {k: v for k, v in data.items() if v is not None}
 
 
-@csv_file_cache
 def get_validation_list(csv_file):
     errors = get_fatal_index_errors(csv_file)
 
@@ -139,7 +138,6 @@ def get_validation_list(csv_file):
     return errors
 
 
-@csv_file_cache
 def get_missing_index_errors(csv_file):
     errors = []
     if csv_file.key_column_index is None:
@@ -151,7 +149,7 @@ def get_missing_index_errors(csv_file):
     return errors
 
 
-@csv_file_cache
+@region.cache_on_arguments()
 def get_fatal_index_errors(csv_file):
     errors = get_missing_index_errors(csv_file)
     if not errors:
@@ -190,5 +188,6 @@ def get_invalid_index_errors(csv_file):
     return errors
 
 
+@region.cache_on_arguments()
 def get_warnings(csv_file):
     return []


### PR DESCRIPTION
There is some internal error occurring in pylibmc during deserialization of the validation classes.  Rather than spend hours debugging, I'm just moving this to the memory cache region.