### PR TITLE
Don't emit low variance warnings when variance is NaN

### DIFF
--- a/metabulo/table_validation.py
+++ b/metabulo/table_validation.py
@@ -248,7 +248,7 @@ def get_low_variance_warnings(csv_file):
     warnings = []
 
     for column_name, value in table.var().items():
-        if value > LOW_VARIANCE_THRESHOLD:
+        if value != value or value > LOW_VARIANCE_THRESHOLD:
             continue
 
         column = csv_file.get_column_by_name(column_name)

--- a/tests/test_table_validation.py
+++ b/tests/test_table_validation.py
@@ -230,3 +230,20 @@ z,b,0,10
     assert warning.type_ == 'low-variance'
     assert warning.severity == 'warning'
     assert warning.column_index == 2
+
+
+def test_low_variance__with_nans(client):
+    table = """
+id,group,col1,col2
+w,a,,2
+x,a,,0
+y,a,,1
+z,b,,10
+"""
+
+    csv_file = csv_file_schema.load({'table': table, 'name': 'table.csv'})
+    db.session.add(csv_file)
+    db.session.commit()
+
+    warnings = get_low_variance_warnings(csv_file)
+    assert warnings == []


### PR DESCRIPTION
This will happen when a column has less than 2 non-nan elements.