### PR TITLE
Fix problems detecting errors in header rows

### DIFF
--- a/metabulo/table_validation.py
+++ b/metabulo/table_validation.py
@@ -160,8 +160,9 @@ def get_fatal_index_errors(csv_file):
     return errors
 
 
-def check_valid_index(index):
+def check_valid_index(series):
     """Check if pandas series can be a valid index."""
+    index = Index(series)
     if index.hasnans:
         return 'Contains NaN\'s'
     if not index.is_unique:
@@ -175,12 +176,18 @@ def check_valid_groups(groups):
 
 
 def get_invalid_index_errors(csv_file):
+    from metabulo.models import TABLE_COLUMN_TYPES, TABLE_ROW_TYPES
+
     errors = []
-    error_data = check_valid_index(csv_file.raw_measurement_table.index)
+    table = csv_file.filter_table_by_types(
+        TABLE_ROW_TYPES.DATA, TABLE_COLUMN_TYPES.INDEX).iloc[:, 0]
+    error_data = check_valid_index(table)
     if error_data:
         errors.append(InvalidPrimaryKey(column_index=csv_file.key_column_index, data=error_data))
 
-    error_data = check_valid_index(csv_file.raw_measurement_table.columns)
+    table = csv_file.filter_table_by_types(
+        TABLE_ROW_TYPES.INDEX, TABLE_COLUMN_TYPES.DATA).iloc[0, :]
+    error_data = check_valid_index(table)
     if error_data:
         errors.append(InvalidHeader(row_index=csv_file.header_row_index, data=error_data))
 

--- a/tests/test_table_validation.py
+++ b/tests/test_table_validation.py
@@ -154,6 +154,14 @@ def test_multiple_invalid_errors(pathological_table):
             'severity': 'error'
         },
         {
+            'context': 'row',
+            'row_index': 0,
+            'type': 'invalid-header',
+            'data': 'Contains NaN\'s',
+            'title': 'Invalid header',
+            'severity': 'error'
+        },
+        {
             'context': 'column',
             'column_index': 1,
             'type': 'invalid-group',


### PR DESCRIPTION
This makes the validation more picky about rows/columns used as primary keys.  Before this change, it could deal with duplicates by appending a unique value.  I found this breaks a number of internal assumptions that I *could* fix, but it is easier to just fail validation for now.