### PR TITLE
fixes for loadings-plot

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -43,6 +43,7 @@ body {
 
   .overflow-auto {
     overflow: auto;
+    max-height: 100%;
   }
 }
 </style>

--- a/web/src/components/Transform.vue
+++ b/web/src/components/Transform.vue
@@ -32,7 +32,6 @@ export default {
     norm() { return this.$store.getters.txType(this.id, 'normalization'); },
     trans() { return this.$store.getters.txType(this.id, 'transformation'); },
     scaling() { return this.$store.getters.txType(this.id, 'scaling'); },
-    transformed() { return this.dataset && this.dataset.transformed; },
     pcaData() { return this.$store.getters.plotData(this.id, 'pca'); },
     pcaValid() { return this.$store.getters.plotValid(this.id, 'pca'); },
     loadingsData() { return this.$store.getters.plotData(this.id, 'loadings'); },
@@ -125,7 +124,7 @@ v-layout.transform-view(row, fill-height)
   v-layout(v-if="!dataset", justify-center, align-center)
     v-progress-circular(indeterminate, size="100", width="5")
     h4.display-1.pa-3 Loading Data Set
-  v-container(v-else)
+  v-container.overflow-auto(v-else)
     v-layout(row, fill-height, ref="contentarea")
       .pa-4
         h3.headline.ml-5 PCA Scores

--- a/web/src/components/vis/VisLoadings.vue
+++ b/web/src/components/vis/VisLoadings.vue
@@ -85,8 +85,8 @@ export default {
   mounted() {
     const svg = select(this.$refs.svg);
     this.axisPlot(svg);
-    this.setXLabel(svg, 'PC1 correlation');
-    this.setYLabel(svg, 'PC2 correlation');
+    this.setXLabel('PC1 correlation');
+    this.setYLabel('PC2 correlation');
     if (this.points) {
       this.update();
     }

--- a/web/src/components/vis/VisLoadings.vue
+++ b/web/src/components/vis/VisLoadings.vue
@@ -64,8 +64,6 @@ export default {
       },
       xrange: [-1.2, 1.2],
       yrange: [-1.2, 1.2],
-      xlabel: 'x correlation',
-      ylabel: 'y correlation',
       duration: 500,
     };
   },
@@ -87,6 +85,8 @@ export default {
   mounted() {
     const svg = select(this.$refs.svg);
     this.axisPlot(svg);
+    this.setXLabel(svg, 'PC1 correlation');
+    this.setYLabel(svg, 'PC2 correlation');
     if (this.points) {
       this.update();
     }

--- a/web/src/components/vis/VisLoadings.vue
+++ b/web/src/components/vis/VisLoadings.vue
@@ -54,6 +54,21 @@ export default {
           && prop.every(val => ['x', 'y', 'col'].every(key => key in val))),
     },
   },
+  data() {
+    return {
+      margin: {
+        top: 20,
+        right: 0,
+        bottom: 50,
+        left: 50,
+      },
+      xrange: [-1.2, 1.2],
+      yrange: [-1.2, 1.2],
+      xlabel: 'x correlation',
+      ylabel: 'y correlation',
+      duration: 500,
+    };
+  },
   computed: {
     group() {
       const { dataset } = this;
@@ -70,19 +85,8 @@ export default {
     },
   },
   mounted() {
-    this.axisPlot({
-      margin: {
-        top: 20,
-        right: 0,
-        bottom: 50,
-        left: 50,
-      },
-      xrange: [-1.2, 1.2],
-      yrange: [-1.2, 1.2],
-      xlabel: 'x correlation',
-      ylabel: 'y correlation',
-      duration: 500,
-    });
+    const svg = select(this.$refs.svg);
+    this.axisPlot(svg);
     if (this.points) {
       this.update();
     }
@@ -97,7 +101,8 @@ export default {
       // Draw the data.
       //
       // Plot the vectors and points in the scatter plot.
-      const sel = this.svg.select('g.plot');
+      const svg = select(this.$refs.svg);
+      const sel = svg.select('g.plot');
       sel.selectAll('line')
         .data(points)
         .join(enter => enter.append('line')

--- a/web/src/components/vis/VisPca.vue
+++ b/web/src/components/vis/VisPca.vue
@@ -165,7 +165,10 @@ export default {
         rawPoints,
       } = this.$props;
 
-      const { xyPoints } = this;
+      const {
+        xyPoints,
+        group,
+      } = this;
 
       // Set the axis labels.
       //
@@ -182,19 +185,18 @@ export default {
       //
       // Set up a colormap and select an arbitrary label to color the nodes.
       const cmap = scaleOrdinal(schemeCategory10);
-      const group = this.group;
 
       // Plot the points in the scatter plot.
       const tooltip = select(this.$refs.tooltip);
       const coordFormat = format('.2f');
-      const sel = svg.select('g.plot')
+      svg.select('g.plot')
         .selectAll('circle')
         .data(xyPoints)
         .join(enter => enter.append('circle')
           .attr('cx', this.scaleX(0))
           .attr('cy', this.scaleY(0))
           .attr('r', 0)
-          .style('fill', (d, i) => group ? cmap(rawPoints.labels[group][i]) : null)
+          .style('fill', (d, i) => (group ? cmap(rawPoints.labels[group][i]) : null))
           .on('mouseover', function mouseover(d) {
             select(this)
               .transition()
@@ -288,7 +290,7 @@ export default {
         .enter()
         .append('g')
         .classed('ellipse', true)
-        .attr('transform', (d) => `translate(${this.scaleX(d.xMean)}, ${this.scaleY(d.yMean)}) rotate(0) scale(1, 1)`)
+        .attr('transform', d => `translate(${this.scaleX(d.xMean)}, ${this.scaleY(d.yMean)}) rotate(0) scale(1, 1)`)
         .append('circle')
         .attr('cx', 0)
         .attr('cy', 0)

--- a/web/src/components/vis/VisPca.vue
+++ b/web/src/components/vis/VisPca.vue
@@ -175,6 +175,8 @@ export default {
       const svg = select(this.$refs.svg);
       this.setRanges(xyPoints);
       this.axisPlot(svg);
+      this.setXLabel(svg, `PC1 (${pctFormat(rawPoints.sdev[0] / totVariance)})`);
+      this.setYLabel(svg, `PC2 (${pctFormat(rawPoints.sdev[1] / totVariance)})`);
 
       // Draw the data.
       //

--- a/web/src/components/vis/VisPca.vue
+++ b/web/src/components/vis/VisPca.vue
@@ -180,6 +180,10 @@ export default {
 
       // Draw the data.
       //
+      // Set up a colormap and select an arbitrary label to color the nodes.
+      const cmap = scaleOrdinal(schemeCategory10);
+      const group = this.group;
+
       // Plot the points in the scatter plot.
       const tooltip = select(this.$refs.tooltip);
       const coordFormat = format('.2f');
@@ -187,9 +191,10 @@ export default {
         .selectAll('circle')
         .data(xyPoints)
         .join(enter => enter.append('circle')
-          .attr('cx', (d, i, nodes) => 60000 * Math.cos(i * Math.PI / nodes.length))
-          .attr('cy', (d, i, nodes) => 60000 * Math.sin(i * Math.PI / nodes.length))
+          .attr('cx', this.scaleX(0))
+          .attr('cy', this.scaleY(0))
           .attr('r', 0)
+          .style('fill', (d, i) => group ? cmap(rawPoints.labels[group][i]) : null)
           .on('mouseover', function mouseover(d) {
             select(this)
               .transition()
@@ -215,24 +220,14 @@ export default {
           }))
         .transition()
         .duration(this.duration)
-        .delay((d, i) => i * 5)
         .attr('r', 2)
         .attr('cx', d => this.scaleX(d.x))
         .attr('cy', d => this.scaleY(d.y));
 
-      // Set up a colormap and select an arbitrary label to color the nodes.
-      const cmap = scaleOrdinal(schemeCategory10);
-      const label = this.group;
-      if (label) {
-        sel.transition()
-          .duration(this.duration)
-          .attr('fill', (d, i) => cmap(rawPoints.labels[label][i]));
-      }
-
       // Decompose the data into its label categories.
       const streams = {};
       xyPoints.forEach((p, i) => {
-        const category = rawPoints.labels[label][i];
+        const category = rawPoints.labels[group][i];
         if (!streams[category]) {
           streams[category] = [];
         }
@@ -293,7 +288,7 @@ export default {
         .enter()
         .append('g')
         .classed('ellipse', true)
-        .attr('transform', 'translate(0, 0) rotate(0) scale(1, 1)')
+        .attr('transform', (d) => `translate(${this.scaleX(d.xMean)}, ${this.scaleY(d.yMean)}) rotate(0) scale(1, 1)`)
         .append('circle')
         .attr('cx', 0)
         .attr('cy', 0)

--- a/web/src/components/vis/VisPca.vue
+++ b/web/src/components/vis/VisPca.vue
@@ -175,8 +175,8 @@ export default {
       const svg = select(this.$refs.svg);
       this.setRanges(xyPoints);
       this.axisPlot(svg);
-      this.setXLabel(svg, `PC1 (${pctFormat(rawPoints.sdev[0] / totVariance)})`);
-      this.setYLabel(svg, `PC2 (${pctFormat(rawPoints.sdev[1] / totVariance)})`);
+      this.setXLabel(`PC1 (${pctFormat(rawPoints.sdev[0] / totVariance)})`);
+      this.setYLabel(`PC2 (${pctFormat(rawPoints.sdev[1] / totVariance)})`);
 
       // Draw the data.
       //

--- a/web/src/components/vis/mixins/axisPlot.js
+++ b/web/src/components/vis/mixins/axisPlot.js
@@ -24,13 +24,13 @@ export const axisPlot = {
     return {
       axisPlotInitialized: false,
       margin: {
-        top: 20,
-        right: 0,
-        bottom: 50,
-        left: 50,
+        top: null,
+        right: null,
+        bottom: null,
+        left: null,
       },
-      xrange: [-1.2, 1.2],
-      yrange: [-1.2, 1.2],
+      xrange: [-1, 1],
+      yrange: [-1, 1],
       duration: 500,
       svg: null,
     };

--- a/web/src/components/vis/mixins/axisPlot.js
+++ b/web/src/components/vis/mixins/axisPlot.js
@@ -31,8 +31,6 @@ export const axisPlot = {
       },
       xrange: [-1.2, 1.2],
       yrange: [-1.2, 1.2],
-      xlabel: 'x axis',
-      ylabel: 'y axis',
       duration: 500,
     };
   },
@@ -73,8 +71,6 @@ export const axisPlot = {
         axisX,
         duration,
         axisY,
-        xlabel,
-        ylabel,
       } = this;
 
       // Set a "master" SVG group.
@@ -107,10 +103,6 @@ export const axisPlot = {
           .duration(duration)
           .call(axisY);
       }
-
-      // Label the axes.
-      this.setXLabel(svg, xlabel);
-      this.setYLabel(svg, ylabel);
 
       // Conclude the initialization process.
       this.axisPlotInitialized = true;

--- a/web/src/components/vis/mixins/axisPlot.js
+++ b/web/src/components/vis/mixins/axisPlot.js
@@ -1,4 +1,3 @@
-import { select } from 'd3-selection';
 import { scaleLinear } from 'd3-scale';
 import { axisBottom, axisLeft } from 'd3-axis';
 
@@ -11,46 +10,72 @@ function labelAxis(label, msg, xFunc, yFunc, rot) {
 }
 
 export const axisPlot = {
-  methods: {
-    axisPlot({
-      margin, xrange, yrange, xlabel, ylabel, duration,
-    }) {
-      // Collect necessary props.
-      const {
-        width,
-        height,
-      } = this.$props;
-
-      // Grab the root SVG element.
-      const svg = select(this.$refs.svg);
-      this.svg = svg;
-
-      // Compute the size of the data rectangle.
-      this.margin = margin;
-
-      const dwidth = width - margin.left - margin.right;
-      this.dwidth = dwidth;
-
-      const dheight = height - margin.top - margin.bottom;
-      this.dheight = dheight;
-
-      // Create X and Y scales.
-      const scaleX = scaleLinear()
+  props: {
+    width: {
+      type: Number,
+      required: true,
+    },
+    height: {
+      type: Number,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      axisPlotInitialized: false,
+      margin: {
+        top: 20,
+        right: 0,
+        bottom: 50,
+        left: 50,
+      },
+      xrange: [-1.2, 1.2],
+      yrange: [-1.2, 1.2],
+      xlabel: 'x axis',
+      ylabel: 'y axis',
+      duration: 500,
+    };
+  },
+  computed: {
+    dwidth() {
+      const { width, margin } = this;
+      return width - margin.left - margin.right;
+    },
+    dheight() {
+      const { height, margin } = this;
+      return height - margin.top - margin.bottom;
+    },
+    scaleX() {
+      const { xrange, dwidth } = this;
+      return scaleLinear()
         .domain(xrange)
         .range([0, dwidth]);
-      this.scaleX = scaleX;
-
-      const scaleY = scaleLinear()
+    },
+    scaleY() {
+      const { yrange, dheight } = this;
+      return scaleLinear()
         .domain(yrange)
         .range([dheight, 0]);
-      this.scaleY = scaleY;
+    },
+    axisX() {
+      return axisBottom(this.scaleX);
+    },
+    axisY() {
+      return axisLeft(this.scaleY);
+    },
 
-      // Create X and Y axis objects.
-      const axisX = axisBottom(scaleX);
-      this.axisX = axisX;
-
-      const axisY = axisLeft(scaleY);
-      this.axisY = axisY;
+  },
+  methods: {
+    axisPlot(svg) {
+      const {
+        margin,
+        dheight,
+        axisX,
+        duration,
+        axisY,
+        xlabel,
+        ylabel,
+      } = this;
 
       // Set a "master" SVG group.
       const master = svg.select('g.master')
@@ -58,8 +83,6 @@ export const axisPlot = {
 
       // Draw axes.
       const axes = master.select('g.axes');
-
-      this.duration = duration;
 
       if (axes.select('.x-axis').size() === 0) {
         axes.append('g')
@@ -86,16 +109,15 @@ export const axisPlot = {
       }
 
       // Label the axes.
-      this.setXLabel(xlabel);
-      this.setYLabel(ylabel);
+      this.setXLabel(svg, xlabel);
+      this.setYLabel(svg, ylabel);
 
       // Conclude the initialization process.
       this.axisPlotInitialized = true;
     },
 
-    setXLabel(msg) {
+    setXLabel(svg, msg) {
       const {
-        svg,
         margin,
         dwidth,
         dheight,
@@ -108,9 +130,8 @@ export const axisPlot = {
         0);
     },
 
-    setYLabel(msg) {
+    setYLabel(svg, msg) {
       const {
-        svg,
         margin,
         dheight,
       } = this;

--- a/web/src/components/vis/mixins/axisPlot.js
+++ b/web/src/components/vis/mixins/axisPlot.js
@@ -32,6 +32,7 @@ export const axisPlot = {
       xrange: [-1.2, 1.2],
       yrange: [-1.2, 1.2],
       duration: 500,
+      svg: null,
     };
   },
   computed: {
@@ -73,6 +74,8 @@ export const axisPlot = {
         axisY,
       } = this;
 
+      this.svg = svg;
+
       // Set a "master" SVG group.
       const master = svg.select('g.master')
         .attr('transform', `translate(${margin.left},${margin.top})`);
@@ -108,11 +111,12 @@ export const axisPlot = {
       this.axisPlotInitialized = true;
     },
 
-    setXLabel(svg, msg) {
+    setXLabel(msg) {
       const {
         margin,
         dwidth,
         dheight,
+        svg,
       } = this;
 
       labelAxis(svg.select('.label.x'),
@@ -122,10 +126,11 @@ export const axisPlot = {
         0);
     },
 
-    setYLabel(svg, msg) {
+    setYLabel(msg) {
       const {
         margin,
         dheight,
+        svg,
       } = this;
 
       labelAxis(svg.select('.label.y'),


### PR DESCRIPTION
@waxlamp first, forgive my meddling.  I did this because I wanted to get into the weeds a bit with your code and understand it, and this was the best way for me to do that.

If you'd like to simply read over it then make whatever changes you decide to keep by hand on your own branch, that won't bother me at all.

This branch consists of a refactor of the axisPlot mixin and a small fix for VisPca because the axes didn't update when scaling changed, so they'd get initialized once then not update.

There's also a container overflow fix (which only helps on Chrome, flexbox heights work slightly different on Firefox and I can't figure out the search terms to find any discussion of the problem).

## axisPlot bits.

First, I really liked the mixin here -- I think it was a good place to use one.  

The main issues I wanted to address were:
* that the mixin was creating properties on the instance in a non-reactive way and from within a method where it isn't obvious that the mixin owns those properties.
* that the properties it was creating were deterministic of the props, and could be factored into computed props.
* that the mixin was creating data properties that the parent would then use, the timings of which were hard to understand.  (e.g. I have to call `axisPlot` and then my component will have some new properties like `svg`.

I'm still learning mixins, but so far I've had a good experience with treating them like abstract base classes (minus the abstract methods bits).  I try to make my mixins attachable to any component:  they don't rely on any data or methods to be present on the components they modify.   In this case, a mixin can't use `$refs.svg` because mixins can't change/own templates.

PTAL and let me know what you think!