### PR TITLE
sessionStore and router fixes

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -14,7 +14,6 @@ v-app
 </template>
 
 <script>
-
 export default {
   name: 'App',
 };

--- a/web/src/common/api.service.js
+++ b/web/src/common/api.service.js
@@ -55,8 +55,10 @@ export const CSVService = {
     return ApiService.post('csv', data);
   },
 
-  upload(data) {
-    return ApiService.upload('csv', data);
+  upload(file) {
+    const formData = new FormData();
+    formData.append('file', file);
+    return ApiService.upload('csv', formData);
   },
 
   download(slug) {

--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -104,7 +104,7 @@ v-layout.cleanup-wrapper(row)
 
   router-view
 
-  v-layout(v-if="!dataset", justify-center, align-center)
+  v-layout(v-if="!dataset || !dataset.ready", justify-center, align-center)
     v-progress-circular(indeterminate, size="100", width="5")
     h4.display-1.pa-3 Loading Table
 

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -5,10 +5,6 @@ import { loadDataset } from '@/utils/mixins';
 export default {
   mixins: [loadDataset],
   props: {
-    id: {
-      type: String,
-      required: true,
-    },
     problem: {
       type: String,
       default: null,
@@ -20,9 +16,16 @@ export default {
     };
   },
   methods: {
-    navigate(id) {
+    valid(dataset) {
+      return this.$store.getters.valid(dataset.id);
+    },
+    navigate(dataset) {
+      const { id } = dataset;
+      const name = this.valid(dataset)
+        ? this.$router.currentRoute.name
+        : 'Cleanup Data';
       this.$router.push({
-        name: this.$router.currentRoute.name,
+        name,
         params: { id },
       });
     },
@@ -50,13 +53,13 @@ v-layout.pretreatment-component(row, fill-height)
     v-layout(column, fill-height)
       v-list.pt-0
         v-list-group(v-for="(dataset, index) in datasets",
-            :key="dataset.source.id",
-            :value="dataset.visible",
+            :key="dataset.id",
+            :value="dataset.id === id",
             :append-icon="null",
-            @click="navigate(dataset.source.id)")
+            @click="navigate(dataset)")
           template(v-slot:activator)
             v-list-tile.file-name
-              v-list-tile-title.title {{ dataset.source.name }}
+              v-list-tile-title.title {{ dataset.name }}
               v-list-tile-action(v-if="dataset.validation.length")
                 v-icon.pr-1(color="warning") {{ $vuetify.icons.warning }}
               v-list-tile-action(v-else)
@@ -65,7 +68,7 @@ v-layout.pretreatment-component(row, fill-height)
 
             v-list-tile.ml-2(
                 :class="{ active: $router.currentRoute.name === 'Cleanup Data' }",
-                @click="$router.push({ path: `/pretreatment/${dataset.source.id}/cleanup` })")
+                @click="$router.push({ path: `/pretreatment/${dataset.id}/cleanup` })")
               v-list-tile-title.pl-2
                 v-icon.pr-1.middle {{ $vuetify.icons.tableEdit }}
                 | Clean Up Table
@@ -87,7 +90,8 @@ v-layout.pretreatment-component(row, fill-height)
 
             v-list-tile.ml-2(
                 :class="{ active: $router.currentRoute.name === 'Transform Data' }",
-                @click="$router.push({ path: `/pretreatment/${dataset.source.id}/transform` })")
+                :disabled="!valid(dataset)",
+                @click="$router.push({ path: `/pretreatment/${dataset.id}/transform` })")
               v-list-tile-title.pl-2
                 v-icon.pr-1.middle {{ $vuetify.icons.bubbles }}
                 | Transform Table

--- a/web/src/components/Upload.vue
+++ b/web/src/components/Upload.vue
@@ -51,8 +51,8 @@ export default {
         const d = datasets[id];
         return {
           file: {
-            name: d.source.name,
-            size: d.source.size, // TODO: fix when server implements this.
+            name: d.name,
+            size: d.size, // TODO: fix when server implements this.
           },
           status: 'done',
           progress: {},
@@ -77,11 +77,11 @@ export default {
       })));
       const promises = this.pendingFiles
         .filter(f => f.status === 'pending')
-        .map(async (file, index) => {
+        .map(async (file) => {
           file.status = 'uploading';
           try {
             await this.$store.dispatch(UPLOAD_CSV,
-              { file: file.file, visible: index === 0 });
+              { file: file.file });
             file.status = 'done';
           } catch (err) {
             file.status = 'error';
@@ -96,8 +96,8 @@ export default {
       this.$router.push({ path: `/pretreatment/${id}/cleanup` });
     },
     async remove(file) {
-      if (file.status === 'done' && file.meta.source) {
-        this.$store.commit(REMOVE_DATASET, { key: file.meta.source.id });
+      if (file.status === 'done' && file.meta.id) {
+        this.$store.commit(REMOVE_DATASET, { key: file.meta.id });
       } else {
         const i = this.pendingFiles.findIndex(f => f.name === file.name && f.size === file.size);
         this.pendingFiles.splice(i, 1);
@@ -143,16 +143,15 @@ v-layout.upload-component(column, fill-height)
             v-list-tile-content.shrink
               v-list-tile-title(v-text="`${file.file.name} `")
               v-list-tile-sub-title(v-text="formatSize(file.file.size)")
-            v-list-tile-content.px-2(v-if="file.status === 'error'")
+            v-list-tile-content.px-2.shrink(v-if="file.status === 'error'")
               v-chip.largetext(small, color="error", text-color="white")
                 v-avatar
                   v-icon {{ $vuetify.icons.warningCircle }}
                 span(v-if="file.meta.name") {{ file.meta.name[0] }}
                 span(v-else-if="file.meta.table") {{ file.meta.table[0] }}
                 span(v-else) Fatal Error
-            v-list-tile-content.px-2(v-else-if="file.status === 'uploading'")
-              v-progress-circular(size="24", color="primary", indeterminate)
-            v-list-tile-content.px-2(v-else-if="file.status === 'done'")
+
+            v-list-tile-content.px-2.shrink(v-if="file.status === 'done'")
               v-layout(row, align-center)
                 v-chip.largetext(v-if="file.meta.validation.length === 0",
                     small, color="success", text-color="white")
@@ -164,9 +163,12 @@ v-layout.upload-component(column, fill-height)
                     v-icon {{ $vuetify.icons.warningCircle }}
                   span Dataset processed with {{ file.meta.validation.length }} validation failures
                 v-btn(small, outline, color="primary", round,
-                    :to="`/pretreatment/${file.meta.source.id}/cleanup`")
+                    :to="`/pretreatment/${file.meta.id}/cleanup`")
                   v-icon.pr-1 {{ $vuetify.icons.eye }}
                   |  View Data
+            v-list-tile-content.px-2.shrink(
+                v-if="file.status === 'uploading' || file.meta.ready === false")
+              v-progress-circular(size="24", color="primary", indeterminate)
             v-spacer
             v-layout(row, shrink)
               v-select.pa-2.tag-selection(hide-details,

--- a/web/src/components/vis/VisLoadings.vue
+++ b/web/src/components/vis/VisLoadings.vue
@@ -70,7 +70,7 @@ export default {
   computed: {
     group() {
       const { dataset } = this;
-      const column = dataset.source.columns.find(elem => elem.column_type === 'group');
+      const column = dataset._source.columns.find(elem => elem.column_type === 'group');
 
       return column.column_header;
     },

--- a/web/src/components/vis/VisPca.vue
+++ b/web/src/components/vis/VisPca.vue
@@ -92,10 +92,10 @@ export default {
     dataset: {
       required: true,
       validator: prop => typeof prop === 'object'
-        && 'source' in prop
-        && typeof prop.source === 'object'
-        && 'columns' in prop.source
-        && Array.isArray(prop.source.columns),
+        && '_source' in prop
+        && typeof prop._source === 'object'
+        && 'columns' in prop._source
+        && Array.isArray(prop._source.columns),
     },
   },
   data() {
@@ -126,7 +126,7 @@ export default {
     },
     group() {
       const { dataset } = this;
-      const column = dataset.source.columns.find(elem => elem.column_type === 'group');
+      const column = dataset._source.columns.find(elem => elem.column_type === 'group');
 
       return column.column_header;
     },
@@ -140,7 +140,6 @@ export default {
           const svg = select(this.$refs.svg);
           this.axisPlot(svg);
         }
-
         this.update();
       }
     },

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -9,13 +9,16 @@ import ApiService from './common/api.service';
 import App from './App.vue';
 import router from './router';
 import store from './store';
+import { LOAD_SESSION } from './store/actions.type';
 import './stylus/main.styl';
 import vuetifyConfig from './utils/vuetifyConfig';
+import { SessionStore } from './utils';
 
 Vue.use(Vuetify, vuetifyConfig);
 Vue.config.productionTip = false;
 
 ApiService.init();
+store.dispatch(LOAD_SESSION, new SessionStore(window));
 
 if (process.env.NODE_ENV === 'production') {
   SentryInit({

--- a/web/src/store/actions.type.js
+++ b/web/src/store/actions.type.js
@@ -1,6 +1,6 @@
 export const CHANGE_AXIS_LABEL = 'change_axis_label';
-export const LOAD_DATASET = 'load_dataset';
 export const LOAD_PLOT = 'load_plot';
+export const LOAD_SESSION = 'load_session';
 export const MUTEX_TRANSFORM_TABLE = 'mutex_transform_table';
 export const UPLOAD_CSV = 'upload_csv';
 export const CHANGE_IMPUTATION_OPTIONS = 'change_imputation_options';

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -166,7 +166,6 @@ const mutations = {
   }) {
     const { last, ranges, type } = state.datasets[key].selected;
     state.datasets[key].selected.last = idx;
-    // this.selected.last = idx;fplo
     if (event.shiftKey && axis === type) {
       ranges.add(last, idx);
     } else if (event.ctrlKey && axis === type) {

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -1,68 +1,110 @@
+import { cloneDeep } from 'lodash';
 import Vue from 'vue';
 import Vuex from 'vuex';
 
-import { convertCsvToRows, RangeList, mapValidationErrors } from '../utils';
+import {
+  convertCsvToRows, RangeList, mapValidationErrors,
+} from '../utils';
 import { CSVService } from '../common/api.service';
 
 import {
   CHANGE_AXIS_LABEL,
   MUTEX_TRANSFORM_TABLE,
-  LOAD_DATASET,
   LOAD_PLOT,
+  LOAD_SESSION,
   UPLOAD_CSV,
   CHANGE_IMPUTATION_OPTIONS,
 } from './actions.type';
 
 import {
-  ADD_SOURCE_DATA,
   REFRESH_PLOT,
   REMOVE_DATASET,
-  SET_TRANSFORMATION,
+  SET_DATASET,
   SET_LAST_ERROR,
   SET_LOADING,
   SET_SELECTION,
+  SET_SESSION_STORE,
+  SET_SOURCE_DATA,
+  SET_TRANSFORMATION,
 } from './mutations.type';
 
 Vue.use(Vuex);
 
+const plotDefaults = {
+  // logic for which mutations invalidate plot data cache is internal to vuex state
+  // this could be more granular.  for now, mutations invalidate all plots.
+  // enumerate plot types
+  pca: {
+    data: null,
+    valid: false,
+  },
+  loadings: {
+    data: null,
+    valid: false,
+  },
+};
+
 const appstate = {
   // map of all datasets in the session by csv UUID
   datasets: {},
+  plots: {},
   lasterror: null,
   loading: false,
+  /** @type {WindowLocalStorage} */
+  store: null,
+  session_id: 'default',
 };
 
 const getters = {
   dataset: state => id => state.datasets[id],
-  txType: state => (id, category) => state.datasets[id] && state.datasets[id][category],
-  plotData: state => (id, name) => state.datasets[id] && state.datasets[id].plots[name].data,
-  plotValid: state => (id, name) => state.datasets[id] && state.datasets[id].plots[name].valid,
+  ready: state => id => state.datasets[id] && state.datasets[id].ready,
+  valid: state => id => getters.ready(state)(id)
+    && state.datasets[id].validation.filter(v => v.severity === 'error').length === 0,
+  txType: state => (id, category) => getters.ready(state)(id)
+    && state.datasets[id][category],
+  plotData: state => (id, name) => getters.ready(state)(id) && state.plots[id][name].data,
+  plotValid: state => (id, name) => getters.ready(state)(id) && state.plots[id][name].valid,
 };
-
 
 /*
  * Private mutation helpers
  */
 function _invalidatePlots(state, { key, plotList }) {
   plotList.forEach((name) => {
-    Vue.set(state.datasets[key].plots[name], 'valid', false);
+    Vue.set(state.plots[key][name], 'valid', false);
   });
+}
+
+/*
+ * Private action helpers
+ */
+export async function load_dataset({ commit }, { dataset_id }) {
+  try {
+    const { data } = await CSVService.get(dataset_id);
+    commit(SET_SOURCE_DATA, { data });
+  } catch (err) {
+    commit(SET_LAST_ERROR, err);
+    throw err;
+  }
 }
 
 const mutations = {
 
-  [ADD_SOURCE_DATA](state, { data, visible }) {
-    const key = data.id;
+  [SET_SOURCE_DATA](state, { data }) {
+    const { id, name, size } = data;
     // Server doesn't guarantee order of indices.
     const rows = data.rows.sort((a, b) => a.row_index - b.row_index);
     const cols = data.columns.sort((a, b) => a.column_index - b.column_index);
     // serialize CSV string as JSON
     const { data: sourcerows } = convertCsvToRows(data.table);
 
-    Vue.set(state.datasets, key, {
+    Vue.set(state.datasets, id, {
       // API response from server
-      source: data,
-      visible,
+      _source: data,
+      id,
+      name,
+      size,
+      ready: true,
       width: sourcerows[0].length, // TODO: get from server
       height: sourcerows.length, // TODO: get from server
       // user- and server-generated lables for rows and columns
@@ -88,43 +130,31 @@ const mutations = {
       imputationMCAR: data.imputation_mcar,
       imputationMNAR: data.imputation_mnar,
       scaling: data.scaling,
-      // data for visualizations
-      plots: {
-        // logic for which mutations invalidate plot data cache is internal to vuex state
-        // this could be more granular.  for now, mutations invalidate all plots.
-        // enumerate plot types
-        pca: {
-          data: null,
-          valid: false,
-        },
-        loadings: {
-          data: null,
-          valid: false,
-        },
-      },
     });
+    if (!state.plots[id]) {
+      Vue.set(state.plots, id, cloneDeep(plotDefaults));
+    }
   },
 
+  [SET_DATASET](state, { dataset }) {
+    Vue.set(state.datasets, dataset.id, dataset);
+    if (!state.plots[dataset.id]) {
+      Vue.set(state.plots, dataset.id, cloneDeep(plotDefaults));
+    }
+  },
 
   [REFRESH_PLOT](state, { key, name, data }) {
-    Vue.set(state.datasets[key].plots[name], 'data', data);
-    Vue.set(state.datasets[key].plots[name], 'valid', true);
+    Vue.set(state.plots[key][name], 'data', data);
+    Vue.set(state.plots[key][name], 'valid', true);
   },
 
   [REMOVE_DATASET](state, { key }) {
     Vue.delete(state.datasets, key);
+    state.store.save(state, state.session_id);
   },
 
   [SET_LAST_ERROR](state, { err }) {
     Vue.set(state, 'lasterror', err);
-  },
-
-  [SET_TRANSFORMATION](state, {
-    key, data, transform_type, category,
-  }) {
-    _invalidatePlots(state, { key, plotList: ['pca', 'loadings'] });
-    Vue.set(state.datasets[key], category, transform_type);
-    Vue.set(state.datasets[key], 'transformed', data);
   },
 
   [SET_LOADING](state, loading) {
@@ -136,7 +166,7 @@ const mutations = {
   }) {
     const { last, ranges, type } = state.datasets[key].selected;
     state.datasets[key].selected.last = idx;
-    // this.selected.last = idx;
+    // this.selected.last = idx;fplo
     if (event.shiftKey && axis === type) {
       ranges.add(last, idx);
     } else if (event.ctrlKey && axis === type) {
@@ -146,16 +176,29 @@ const mutations = {
       state.datasets[key].selected.type = axis;
     }
   },
+
+  [SET_SESSION_STORE](state, { store, session_id }) {
+    Vue.set(state, 'store', store);
+    Vue.set(state, 'session_id', session_id);
+  },
+
+  [SET_TRANSFORMATION](state, {
+    key, data, transform_type, category,
+  }) {
+    _invalidatePlots(state, { key, plotList: ['pca', 'loadings'] });
+    Vue.set(state.datasets[key], category, transform_type);
+    Vue.set(state.datasets[key], 'transformed', data);
+  },
 };
 
 const actions = {
-  async [UPLOAD_CSV]({ commit }, { file, visible }) {
-    const formData = new FormData();
-    formData.append('file', file);
+
+  async [UPLOAD_CSV]({ state, commit }, { file }) {
     commit(SET_LOADING, true);
     try {
-      const { data } = await CSVService.upload(formData);
-      commit(ADD_SOURCE_DATA, { data, visible });
+      const { data } = await CSVService.upload(file);
+      commit(SET_SOURCE_DATA, { data });
+      state.store.save(state, state.session_id);
     } catch (err) {
       commit(SET_LAST_ERROR, err);
       commit(SET_LOADING, false);
@@ -164,12 +207,35 @@ const actions = {
     commit(SET_LOADING, false);
   },
 
-  async [LOAD_DATASET]({ commit }, { dataset_id }) {
+  async [LOAD_PLOT]({ commit }, { dataset_id, name }) {
     try {
-      const { data } = await CSVService.get(dataset_id);
-      commit(ADD_SOURCE_DATA, { data, visible: true });
+      const { data } = await CSVService.getPlot(dataset_id, name);
+      commit(REFRESH_PLOT, { key: dataset_id, name, data });
     } catch (err) {
       commit(SET_LAST_ERROR, err);
+      throw err;
+    }
+  },
+
+  /**
+   * Load datasets from session into the store.
+   * @param {Object} vuex
+   * @param {import('../utils').SessionStore} sessionStore Store
+   */
+  async [LOAD_SESSION]({ commit }, store, session_id = 'default') {
+    commit(SET_LOADING, true);
+    commit(SET_SESSION_STORE, { store, session_id });
+    try {
+      const { datasets } = store.load(session_id);
+      await Promise.all(Object.keys(datasets).map((dataset_id) => {
+        const dataset = datasets[dataset_id];
+        commit(SET_DATASET, { dataset });
+        return load_dataset({ commit }, { dataset_id: dataset.id });
+      }));
+      commit(SET_LOADING, false);
+    } catch (err) {
+      commit(SET_LAST_ERROR, err);
+      commit(SET_LOADING, false);
       throw err;
     }
   },
@@ -198,7 +264,7 @@ const actions = {
     try {
       const { data } = await CSVService.updateLabel(dataset_id, changes);
       const { selected } = state.datasets[dataset_id];
-      commit(ADD_SOURCE_DATA, { data: { ...data, selected }, visible: true });
+      commit(SET_SOURCE_DATA, { data: { ...data, selected } });
     } catch (err) {
       commit(SET_LAST_ERROR, err);
       commit(SET_LOADING, false);
@@ -207,20 +273,10 @@ const actions = {
     commit(SET_LOADING, false);
   },
 
-  async [LOAD_PLOT]({ commit }, { dataset_id, name }) {
-    try {
-      const { data } = await CSVService.getPlot(dataset_id, name);
-      commit(REFRESH_PLOT, { key: dataset_id, name, data });
-    } catch (err) {
-      commit(SET_LAST_ERROR, err);
-      throw err;
-    }
-  },
-
-  async [CHANGE_IMPUTATION_OPTIONS]({ commit, dispatch }, { dataset_id, options }) {
+  async [CHANGE_IMPUTATION_OPTIONS]({ commit }, { dataset_id, options }) {
     commit(SET_LOADING, true);
     await CSVService.setImputation(dataset_id, options);
-    await dispatch(LOAD_DATASET, { dataset_id });
+    await load_dataset({ commit }, { dataset_id });
     commit(SET_LOADING, false);
   },
 };

--- a/web/src/store/mutations.type.js
+++ b/web/src/store/mutations.type.js
@@ -1,8 +1,9 @@
-export const ADD_SOURCE_DATA = 'add_source_data';
 export const REFRESH_PLOT = 'refresh_plot';
 export const REMOVE_DATASET = 'remove_dataset';
-export const SET_AXIS_LABEL = 'set_axis_label';
+export const SET_DATASET = 'set_dataset';
 export const SET_LAST_ERROR = 'set_last_error';
 export const SET_LOADING = 'set_loading';
 export const SET_SELECTION = 'set_selection';
+export const SET_SOURCE_DATA = 'set_source_data';
+export const SET_SESSION_STORE = 'set_session_store';
 export const SET_TRANSFORMATION = 'set_transformation';

--- a/web/src/utils/index.js
+++ b/web/src/utils/index.js
@@ -1,6 +1,7 @@
 import papa from 'papaparse';
 import { validationMeta } from './constants';
 import RangeList from './rangelist';
+import SessionStore from './sessionStore';
 
 /**
  * A function to group an array of objects
@@ -90,4 +91,5 @@ export {
   convertCsvToRows,
   mapValidationErrors,
   RangeList,
+  SessionStore,
 };

--- a/web/src/utils/mixins.js
+++ b/web/src/utils/mixins.js
@@ -1,19 +1,25 @@
-import { LOAD_DATASET } from '../store/actions.type';
+import { load_dataset } from '../store';
 
 /**
  * Load dataset from server for any view where
  * dataset_id is defined
  */
 const loadDataset = {
-  data() {
-    return {
-      loaded: !!this.$store.state.datasets[this.id],
-    };
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    datasetLoaded() {
+      return !!this.$store.state.datasets[this.id];
+    },
   },
   created() {
     const dataset = this.$store.getters.dataset(this.id);
     if (!dataset) {
-      this.$store.dispatch(LOAD_DATASET, { dataset_id: this.id });
+      load_dataset(this.$store, { dataset_id: this.id });
     }
   },
 };

--- a/web/src/utils/sessionStore.js
+++ b/web/src/utils/sessionStore.js
@@ -1,0 +1,55 @@
+class SessionStore {
+  /**
+   * @param {WindowLocalStorage} provider localStorageApi provider
+   */
+  constructor(provider) {
+    this.provider = provider;
+  }
+
+  load(sessionId = 'default') {
+    const sessionString = this.provider.localStorage.getItem('session') || '{}';
+    try {
+      const session = JSON.parse(sessionString);
+      const { datasets = {} } = session[sessionId] || {};
+      return { datasets };
+    } catch (err) {
+      this.provider.localStorage.setItem(
+        'session',
+        JSON.stringify({ [sessionId]: { datasets: {} } }),
+      );
+      return { datasets: {} };
+    }
+  }
+
+  save(state, sessionId = 'default') {
+    const rawDatasetIDs = Object.keys(state.datasets);
+    const datasets = {};
+    rawDatasetIDs.forEach((id) => {
+      // the keys from dataset to cache in localStorage;
+      const d = state.datasets[id];
+      const {
+        name,
+        size,
+        width,
+        height,
+        validation,
+        selected,
+      } = d;
+      datasets[id] = {
+        id,
+        name,
+        size,
+        width,
+        height,
+        validation,
+        selected,
+        ready: false,
+      };
+    });
+    this.provider.localStorage.setItem('session', JSON.stringify({
+      [sessionId]: { datasets },
+    }));
+  }
+}
+
+export default SessionStore;

--- a/web/tests/sessionstore.spec.js
+++ b/web/tests/sessionstore.spec.js
@@ -1,0 +1,27 @@
+import SessionStore from '../src/utils/sessionStore';
+
+describe('SessionStore', () => {
+  it('Loads correct defaults from localStorage', () => {
+    const mockProvider = {
+      localStorage: {
+        getItem: () => '',
+      },
+    };
+    const ss = new SessionStore(mockProvider);
+    const defaults = ss.load('does_not_matter');
+    expect(Object.keys(defaults.datasets).length).toBe(0);
+  });
+
+  it('Sets the correct defaults when localStorage becomes corrupt', () => {
+    let storageVal = null;
+    const mockProvider = {
+      localStorage: {
+        getItem: () => '{ invalid json',
+        setItem: (key, newval) => storageVal = newval,
+      },
+    };
+    const ss = new SessionStore(mockProvider);
+    ss.load('sessionstring');
+    expect(JSON.parse(storageVal)).toHaveProperty('sessionstring');
+  });
+});

--- a/web/tests/sessionstore.spec.js
+++ b/web/tests/sessionstore.spec.js
@@ -17,7 +17,9 @@ describe('SessionStore', () => {
     const mockProvider = {
       localStorage: {
         getItem: () => '{ invalid json',
-        setItem: (key, newval) => storageVal = newval,
+        setItem: (key, newval) => {
+          storageVal = newval;
+        },
       },
     };
     const ss = new SessionStore(mockProvider);


### PR DESCRIPTION
## New feature: localStorage sessions

When you upload a CSV, a reference to it will be stored in localStorage.  When you return to this application, those references will be read and their data loaded from the server.  

This PR adds a new "ready" state to each dataset, allowing for a new state where localStorage has been read and loaded into vuex, but the actual data for the dataset has yet to return from server.  

## Bug fixes

All the bugs associated with routing and the expansion list should be resolved here.  This includes the issue with moving between datasets whose transform views are open.

## Notes

This moves the `dataset.source` property to `dataset._source`.  It is a raw copy of the response from the server without any validation or processing, so using it should be avoided in most cases (I think the plots are the exception, but for all other uses, I've moved the expected properties from within source to direct properties of the dataset, like `id` and `name`.

