### PR TITLE
Remove per-column stats from responses

### DIFF
--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -379,13 +379,13 @@ class TableColumnSchema(BaseSchema):
     column_type = fields.Str(required=True, validate=validate.OneOf(TABLE_COLUMN_TYPES))
     data_column_index = fields.Int(dump_only=True, allow_none=True)
 
-    missing_percent = fields.Float(dump_only=True, allow_none=True)
-    data_variance = fields.Float(dump_only=True, allow_none=True, allow_nan=True)
+    # missing_percent = fields.Float(dump_only=True, allow_none=True)
+    # data_variance = fields.Float(dump_only=True, allow_none=True, allow_nan=True)
 
     csv_file = fields.Nested(
         CSVFileSchema, exclude=['rows', 'columns'], dump_only=True)
 
-    @post_dump
+    # @post_dump
     def coerce_nan(self, data):
         if data['data_variance'] != data['data_variance']:
             data['data_variance'] = None

--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -377,19 +377,9 @@ class TableColumnSchema(BaseSchema):
     column_header = fields.Str(dump_only=True)
     column_index = fields.Int(required=True, validate=validate.Range(min=0))
     column_type = fields.Str(required=True, validate=validate.OneOf(TABLE_COLUMN_TYPES))
-    data_column_index = fields.Int(dump_only=True, allow_none=True)
-
-    # missing_percent = fields.Float(dump_only=True, allow_none=True)
-    # data_variance = fields.Float(dump_only=True, allow_none=True, allow_nan=True)
 
     csv_file = fields.Nested(
         CSVFileSchema, exclude=['rows', 'columns'], dump_only=True)
-
-    # @post_dump
-    def coerce_nan(self, data):
-        if data['data_variance'] != data['data_variance']:
-            data['data_variance'] = None
-        return data
 
 
 class TableRow(db.Model):
@@ -427,7 +417,6 @@ class TableRowSchema(BaseSchema):
     row_name = fields.Str(dump_only=True)
     row_index = fields.Int(required=True, validate=validate.Range(min=0))
     row_type = fields.Str(required=True, validate=validate.OneOf(TABLE_ROW_TYPES))
-    data_row_index = fields.Int(dump_only=True, allow_none=True)
 
     csv_file = fields.Nested(
         CSVFileSchema, exclude=['rows', 'columns'], dump_only=True)

--- a/tests/test_row_column.py
+++ b/tests/test_row_column.py
@@ -31,28 +31,23 @@ def test_list_columns(client, table):
     assert resp.json == [{
         'column_header': 'id',
         'column_index': 0,
-        'column_type': 'key',
-        'data_column_index': None
+        'column_type': 'key'
     }, {
         'column_header': 'group',
         'column_index': 1,
-        'column_type': 'group',
-        'data_column_index': None
+        'column_type': 'group'
     }, {
         'column_header': 'meta',
         'column_index': 2,
-        'column_type': 'measurement',
-        'data_column_index': 0
+        'column_type': 'measurement'
     }, {
         'column_header': 'col1',
         'column_index': 3,
-        'column_type': 'measurement',
-        'data_column_index': 1
+        'column_type': 'measurement'
     }, {
         'column_header': 'col2',
         'column_index': 4,
-        'column_type': 'measurement',
-        'data_column_index': 2
+        'column_type': 'measurement'
     }]
 
 
@@ -63,23 +58,19 @@ def test_list_rows(client, table):
     assert resp.json == [{
         'row_name': 'id',
         'row_index': 0,
-        'row_type': 'header',
-        'data_row_index': None
+        'row_type': 'header'
     }, {
         'row_name': 'row1',
         'row_index': 1,
-        'row_type': 'sample',
-        'data_row_index': 0
+        'row_type': 'sample'
     }, {
         'row_name': 'row2',
         'row_index': 2,
-        'row_type': 'sample',
-        'data_row_index': 1
+        'row_type': 'sample'
     }, {
         'row_name': 'row3',
         'row_index': 3,
-        'row_type': 'sample',
-        'data_row_index': 2
+        'row_type': 'sample'
     }]
 
 
@@ -90,8 +81,7 @@ def test_get_column(client, table):
     assert resp.json == {
         'column_header': 'col1',
         'column_index': 3,
-        'column_type': 'measurement',
-        'data_column_index': 1
+        'column_type': 'measurement'
     }
 
 
@@ -102,8 +92,7 @@ def test_get_row(client, table):
     assert resp.json == {
         'row_name': 'row1',
         'row_index': 1,
-        'row_type': 'sample',
-        'data_row_index': 0
+        'row_type': 'sample'
     }
 
 

--- a/tests/test_row_column.py
+++ b/tests/test_row_column.py
@@ -32,37 +32,27 @@ def test_list_columns(client, table):
         'column_header': 'id',
         'column_index': 0,
         'column_type': 'key',
-        'data_column_index': None,
-        'data_variance': None,
-        'missing_percent': None
+        'data_column_index': None
     }, {
         'column_header': 'group',
         'column_index': 1,
         'column_type': 'group',
-        'data_column_index': None,
-        'data_variance': None,
-        'missing_percent': None
+        'data_column_index': None
     }, {
         'column_header': 'meta',
         'column_index': 2,
         'column_type': 'measurement',
-        'data_column_index': 0,
-        'data_variance': None,
-        'missing_percent': 1.0
+        'data_column_index': 0
     }, {
         'column_header': 'col1',
         'column_index': 3,
         'column_type': 'measurement',
-        'data_column_index': 1,
-        'data_variance': 3.25,
-        'missing_percent': 0.0
+        'data_column_index': 1
     }, {
         'column_header': 'col2',
         'column_index': 4,
         'column_type': 'measurement',
-        'data_column_index': 2,
-        'data_variance': 4.0,
-        'missing_percent': 0.0
+        'data_column_index': 2
     }]
 
 
@@ -101,9 +91,7 @@ def test_get_column(client, table):
         'column_header': 'col1',
         'column_index': 3,
         'column_type': 'measurement',
-        'data_column_index': 1,
-        'data_variance': 3.25,
-        'missing_percent': 0.0
+        'data_column_index': 1
     }
 
 


### PR DESCRIPTION
The web client currently does not use this information.  It saves 37% of the time required to serialize large tables.