### PR TITLE
Fix/148

### DIFF
--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -12,87 +12,12 @@ import {
 } from '@/utils/constants';
 import { base26Converter } from '@/utils';
 import SaveStatus from '@/components/SaveStatus.vue';
+import DataTable from '@/components/DataTable.vue';
 
-function updateTable(el, binding) {
-  const { dataset, id, activeClasses, setSelection } = binding.value;
-  const colgroup = el.getElementsByTagName('colgroup')[0];
-  const body = el.getElementsByTagName('tbody')[0];
-  const columns = colgroup.children;
-  const rows = body.children;
-  for(let index = 0; index < (columns.length - 1); index += 1) {
-    const col = columns[index + 1]; // Account for 0th being empty
-    col.classList.remove('first', 'last', 'active', 'key', 'group', 'metadata', 'masked', 'measurement');
-    col.classList.add(...activeClasses(index, 'column'));
-    col.classList.add(dataset.column.labels[index]);
-  }
-
-  for(let index = 0; index < (rows.length); index += 1) {
-    const row = rows[index];
-    row.classList.remove('first', 'last', 'active', 'header', 'metadata', 'masked', 'sample');
-    row.classList.add(...activeClasses(index, 'row'));
-    row.classList.add(dataset.row.labels[index]);
-  }
-}
-
-function renderTable(el, binding) {
-  while(el.firstChild) {
-    el.removeChild(el.firstChild);
-  }
-
-  const { dataset, id, activeClasses, setSelection } = binding.value;
-  const thead = document.createElement('thead');
-  const colgroup = document.createElement('colgroup');
-  const tr0 = document.createElement('tr');
-  const th0 = document.createElement('th');
-  const col0 = document.createElement('col');
-  tr0.appendChild(th0);
-  colgroup.appendChild(col0);
-
-  dataset.column.labels.forEach((col, index) => {
-    const coln = document.createElement('col');
-    const thn = document.createElement('th');
-    const span = document.createElement('span');
-    span.innerText = base26Converter(index + 1);
-    thn.onclick = (event) => {
-      setSelection({ key: id, event, axis: 'column', idx: index });
-    }
-    thn.classList.add('control', 'px-2')
-    coln.classList.add(...activeClasses(index, 'column'));
-    coln.classList.add(dataset.column.labels[index]);
-    thn.appendChild(span);
-    tr0.appendChild(thn);
-    colgroup.appendChild(coln);
-  });
-  thead.appendChild(tr0);
-  
-  const tbody = document.createElement('tbody');
-  dataset.sourcerows.forEach((row, index) => {
-    const trn = document.createElement('tr');
-    trn.classList.add(...['datarow'].concat(activeClasses(index, 'row')));
-    trn.classList.add(dataset.row.labels[index]);
-    tbody.appendChild(trn);
-    const td = document.createElement('td');
-    td.innerText = index + 1;
-    td.classList.add('control');
-    td.onclick = (event) => {
-      setSelection({ key: id, event, axis: 'row', idx: index });
-    }
-    trn.appendChild(td);
-    row.forEach((col, idx2) => {
-      const tdn = document.createElement('td');
-      tdn.innerText = col;
-      trn.appendChild(tdn);
-      tdn.classList.add('row');
-    });
-  });
-
-  el.appendChild(colgroup);
-  el.appendChild(thead);
-  el.appendChild(tbody);
-}
 
 export default {
   components: {
+    DataTable,
     SaveStatus,
   },
   props: {
@@ -147,12 +72,6 @@ export default {
       this.imputation.mcar = this.dataset.imputationMCAR;
     },
   },
-  directives: {
-    dataTable: {
-      inserted: renderTable,
-      update: updateTable,
-    }
-  },
   methods: {
     ...mapMutations({ setSelection: SET_SELECTION }),
     base26Converter,
@@ -167,23 +86,6 @@ export default {
         dataset_id: this.id,
         options: this.imputation,
       });
-    },
-    activeClasses(index, axisName) {
-      if (axisName === this.selected.type) {
-        const includes = this.selected.ranges.includes(index);
-        const classList = [];
-        if (includes.member) {
-          classList.push('active');
-        }
-        if (includes.first) {
-          classList.push('first');
-        }
-        if (includes.last) {
-          classList.push('last');
-        }
-        return classList;
-      }
-      return [];
     },
   },
 };
@@ -247,17 +149,10 @@ v-layout.cleanup-wrapper(row)
       v-icon {{ $vuetify.icons.download }}
 
     .overflow-auto
-      table.cleanup-table(v-data-table="this")
+      data-table(v-bind="{ id, dataset, selected }", @setSelection="setSelection")
 </template>
 
 <style lang="scss">
-@mixin masked() {
-  background-color: var(--v-secondary-lighten3);
-  box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten2);
-  font-weight: 300;
-  color: var(--v-secondary-base);
-}
-
 .cleanup-wrapper {
   width: 100%;
 
@@ -299,97 +194,5 @@ v-layout.cleanup-wrapper(row)
       margin: 4px;
     }
   }
-
-  .cleanup-table {
-    border-spacing: 0px;
-    user-select: none;
-    table-layout: fixed;
-    border-collapse: collapse;
-
-    .key, .metadata, .header, .group {
-      color: white;
-      font-weight: 700;
-      text-align: left;
-    }
-    
-    colgroup {
-      col {
-        &.active {
-          background: linear-gradient(0deg,rgba(161, 213, 255, 0.3),rgba(161, 213, 255, 0.3));
-          border-left-color: red !important;
-        }
-
-        &.active.key, &.key {
-          background-color:  var(--v-primary-lighten4);
-        }
-
-        &.active.metadata, &.metadata {
-          background-color:  var(--v-accent2-lighten3);
-        }
-
-        &.active.group, &.group {
-          background-color:   var(--v-accent3-lighten3);
-        }
-      }
-    }
-
-    tr {
-
-      th, td {
-        // border: 1px solid var(--v-secondary-lighten1);
-        padding: 2px 5px;
-        text-align: center;
-        white-space: nowrap;
-
-        &.control {
-          cursor: pointer;
-          font-weight: 300;
-        }
-      }
-
-      &.active td {
-        background: linear-gradient(0deg,rgba(161, 213, 255, 0.3),rgba(161, 213, 255, 0.3));
-
-        &.group,
-        &.key,
-        &.metadata,
-        &.masked {
-          // box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
-        }
-      }
-    }
-
-    tr.datarow {
-      
-      &.header {
-        td {
-          background-color: var(--v-accent-lighten1);
-        }
-      }
-
-      &.metadata {
-        td {
-          background-color: var(--v-accent2-lighten2);
-          // box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
-        }
-      }
-
-      &.header,
-      &.metadata {
-        td.key, td.metadata, td.group {
-          @include masked();
-        }
-      }
-    }
-
-    tr.datarow {
-      &.masked td,
-      td.masked,
-      th.masked {
-        @include masked();
-      }
-    }
-  }
 }
-
 </style>

--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -336,7 +336,7 @@ v-layout.cleanup-wrapper(row)
     tr {
 
       th, td {
-        border: 1px solid var(--v-secondary-lighten1);
+        // border: 1px solid var(--v-secondary-lighten1);
         padding: 2px 5px;
         text-align: center;
         white-space: nowrap;

--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -13,6 +13,45 @@ import {
 import { base26Converter } from '@/utils';
 import SaveStatus from '@/components/SaveStatus.vue';
 
+function renderTable(el, binding) {
+  while(el.firstChild) {
+    el.removeChild(el.firstChild);
+  }
+  const { dataset, id, activeClasses } = binding.value;
+  const thead = document.createElement('thead');
+  const tr0 = document.createElement('tr');
+  const th0 = document.createElement('th');
+  tr0.appendChild(th0);
+  dataset.column.labels.forEach((col, index) => {
+    const thn = document.createElement('th');
+    const span = document.createElement('span');
+    span.innerText = base26Converter(index + 1);
+    thn.onclick = (event) => {
+      binding.value.setSelection({ key: id, event, axis: 'column', idx: index });
+    }
+    thn.classList.add(...['control', 'px-2'].concat(activeClasses(index, 'column')));
+    thn.appendChild(span);
+    tr0.appendChild(thn);
+  });
+  thead.appendChild(tr0);
+  const tbody = document.createElement('tbody');
+  dataset.sourcerows.forEach((row, index) => {
+    const trn = document.createElement('tr');
+    tbody.appendChild(trn);
+    const td = document.createElement('td');
+    td.innerText = index + 1;
+    trn.appendChild(td);
+    row.forEach((col, idx2) => {
+      const tdn = document.createElement('td');
+      tdn.innerText = col;
+      trn.appendChild(tdn);
+      
+    });
+  });
+  el.appendChild(thead);
+  el.appendChild(tbody);
+}
+
 export default {
   components: {
     SaveStatus,
@@ -69,6 +108,34 @@ export default {
       this.imputation.mcar = this.dataset.imputationMCAR;
     },
   },
+  directives: {
+    dataTable: {
+      inserted: renderTable,
+      update: renderTable,
+    }
+  },
+          //- thead
+        //-   tr
+        //-     th
+        //-     th.control.px-2(
+        //-         v-for="(col, index) in dataset.column.labels",
+        //-         :class="activeClasses(index, 'column')",
+        //-         @click="setSelection({ key: id, event: $event, axis: 'column', idx: index })")
+        //-       span(v-if="col === defaultColOption") {{ base26Converter(index + 1) }}
+        //-       v-icon(v-else, small) {{ $vuetify.icons[col] }}
+
+                //- tbody
+        //-   tr.datarow(v-for="(row, index) in dataset.sourcerows",
+        //-       :key="`${index}${row[0]}`",
+        //-       :class="{[dataset.row.labels[index]]: true, ...activeClasses(index, 'row')}")
+        //-     td.control.px-2(
+        //-         @click="setSelection({ key: id, event: $event, axis: 'row', idx: index })")
+        //-       span(v-if="dataset.row.labels[index] === defaultRowOption") {{ index + 1 }}
+        //-       v-icon(v-else, small) {{ $vuetify.icons[dataset.row.labels[index]] }}
+        //-     td.px-2.row(
+        //-         v-for="(col, idx2) in row",
+        //-         :class="{[dataset.column.labels[idx2]]: true, ...activeClasses(idx2, 'column')}",
+        //-         :key="`${index}.${idx2}`") {{ col }}
   methods: {
     ...mapMutations({ setSelection: SET_SELECTION }),
     base26Converter,
@@ -87,13 +154,19 @@ export default {
     activeClasses(index, axisName) {
       if (axisName === this.selected.type) {
         const includes = this.selected.ranges.includes(index);
-        return {
-          active: includes.member,
-          first: includes.first,
-          last: includes.last,
-        };
+        const classList = [];
+        if (includes.member) {
+          classList.push('active');
+        }
+        if (includes.first) {
+          classList.push('first');
+        }
+        if (includes.last) {
+          classList.push('last');
+        }
+        return classList;
       }
-      return {};
+      return [];
     },
   },
 };
@@ -157,30 +230,30 @@ v-layout.cleanup-wrapper(row)
       v-icon {{ $vuetify.icons.download }}
 
     .overflow-auto
-      table.cleanup-table
+      table.cleanup-table(v-data-table="this")
 
-        thead
-          tr
-            th
-            th.control.px-2(
-                v-for="(col, index) in dataset.column.labels",
-                :class="activeClasses(index, 'column')",
-                @click="setSelection({ key: id, event: $event, axis: 'column', idx: index })")
-              span(v-if="col === defaultColOption") {{ base26Converter(index + 1) }}
-              v-icon(v-else, small) {{ $vuetify.icons[col] }}
+        //- thead
+        //-   tr
+        //-     th
+        //-     th.control.px-2(
+        //-         v-for="(col, index) in dataset.column.labels",
+        //-         :class="activeClasses(index, 'column')",
+        //-         @click="setSelection({ key: id, event: $event, axis: 'column', idx: index })")
+        //-       span(v-if="col === defaultColOption") {{ base26Converter(index + 1) }}
+        //-       v-icon(v-else, small) {{ $vuetify.icons[col] }}
 
-        tbody
-          tr.datarow(v-for="(row, index) in dataset.sourcerows",
-              :key="`${index}${row[0]}`",
-              :class="{[dataset.row.labels[index]]: true, ...activeClasses(index, 'row')}")
-            td.control.px-2(
-                @click="setSelection({ key: id, event: $event, axis: 'row', idx: index })")
-              span(v-if="dataset.row.labels[index] === defaultRowOption") {{ index + 1 }}
-              v-icon(v-else, small) {{ $vuetify.icons[dataset.row.labels[index]] }}
-            td.px-2.row(
-                v-for="(col, idx2) in row",
-                :class="{[dataset.column.labels[idx2]]: true, ...activeClasses(idx2, 'column')}",
-                :key="`${index}.${idx2}`") {{ col }}
+        //- tbody
+        //-   tr.datarow(v-for="(row, index) in dataset.sourcerows",
+        //-       :key="`${index}${row[0]}`",
+        //-       :class="{[dataset.row.labels[index]]: true, ...activeClasses(index, 'row')}")
+        //-     td.control.px-2(
+        //-         @click="setSelection({ key: id, event: $event, axis: 'row', idx: index })")
+        //-       span(v-if="dataset.row.labels[index] === defaultRowOption") {{ index + 1 }}
+        //-       v-icon(v-else, small) {{ $vuetify.icons[dataset.row.labels[index]] }}
+        //-     td.px-2.row(
+        //-         v-for="(col, idx2) in row",
+        //-         :class="{[dataset.column.labels[idx2]]: true, ...activeClasses(idx2, 'column')}",
+        //-         :key="`${index}.${idx2}`") {{ col }}
 </template>
 
 <style lang="scss">
@@ -236,6 +309,7 @@ v-layout.cleanup-wrapper(row)
   .cleanup-table {
     border-spacing: 0px;
     user-select: none;
+    table-layout: fixed;
 
     .key, .metadata, .header, .group {
       color: white;

--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -149,7 +149,7 @@ v-layout.cleanup-wrapper(row)
       v-icon {{ $vuetify.icons.download }}
 
     .overflow-auto
-      data-table(v-bind="{ id, dataset, selected }", @setSelection="setSelection")
+      data-table(v-bind="{ id, dataset, selected }", @setselection="setSelection")
 </template>
 
 <style lang="scss">

--- a/web/src/components/DataTable.vue
+++ b/web/src/components/DataTable.vue
@@ -11,23 +11,40 @@ function updateTable(el, binding) {
   const body = el.getElementsByTagName('tbody')[0];
   const columns = colgroup.children;
   const rows = body.children;
-  for(let index = 0; index < (columns.length - 1); index += 1) {
+  for (let index = 0; index < columns.length - 1; index += 1) {
     const col = columns[index + 1]; // Account for 0th being empty
-    col.classList.remove('first', 'last', 'active', 'key', 'group', 'metadata', 'masked', 'measurement');
+    col.classList.remove(
+      'first',
+      'last',
+      'active',
+      'key',
+      'group',
+      'metadata',
+      'masked',
+      'measurement'
+    );
     col.classList.add(...activeClasses(index, 'column'));
     col.classList.add(dataset.column.labels[index]);
   }
 
-  for(let index = 0; index < (rows.length); index += 1) {
+  for (let index = 0; index < rows.length; index += 1) {
     const row = rows[index];
-    row.classList.remove('first', 'last', 'active', 'header', 'metadata', 'masked', 'sample');
+    row.classList.remove(
+      'first',
+      'last',
+      'active',
+      'header',
+      'metadata',
+      'masked',
+      'sample'
+    );
     row.classList.add(...activeClasses(index, 'row'));
     row.classList.add(dataset.row.labels[index]);
   }
 }
 
 function renderTable(el, binding) {
-  while(el.firstChild) {
+  while (el.firstChild) {
     el.removeChild(el.firstChild);
   }
   const { dataset, id, activeClasses, setSelection } = binding.value;
@@ -44,10 +61,10 @@ function renderTable(el, binding) {
     const thn = document.createElement('th');
     const span = document.createElement('span');
     span.innerText = base26Converter(index + 1);
-    thn.onclick = (event) => {
+    thn.onclick = event => {
       setSelection({ key: id, event, axis: 'column', idx: index });
-    }
-    thn.classList.add('control', 'px-2')
+    };
+    thn.classList.add('control', 'px-2');
     coln.classList.add(...activeClasses(index, 'column'));
     coln.classList.add(dataset.column.labels[index]);
     thn.appendChild(span);
@@ -55,7 +72,7 @@ function renderTable(el, binding) {
     colgroup.appendChild(coln);
   });
   thead.appendChild(tr0);
-  
+
   const tbody = document.createElement('tbody');
   dataset.sourcerows.forEach((row, index) => {
     const trn = document.createElement('tr');
@@ -65,9 +82,9 @@ function renderTable(el, binding) {
     const td = document.createElement('td');
     td.innerText = index + 1;
     td.classList.add('control');
-    td.onclick = (event) => {
+    td.onclick = event => {
       setSelection({ key: id, event, axis: 'row', idx: index });
-    }
+    };
     trn.appendChild(td);
     row.forEach((col, idx2) => {
       const tdn = document.createElement('td');
@@ -86,26 +103,30 @@ export default {
   props: {
     dataset: {
       type: Object,
-      required: true,
+      required: true
     },
     id: {
       type: String,
-      required: true,
+      required: true
     },
     selected: {
       type: Object,
-      required: true,
-    },
+      required: true
+    }
   },
   directives: {
     dataTable: {
       inserted: renderTable,
-      update: updateTable,
+      update: updateTable
     }
   },
   computed: {
-    selectedRanges() { return this.selected.ranges; },
-    selectedType() { return this.selected.type; },
+    selectedRanges() {
+      return this.selected.ranges;
+    },
+    selectedType() {
+      return this.selected.type;
+    }
   },
   methods: {
     activeClasses(index, axisName) {
@@ -127,16 +148,15 @@ export default {
       return [];
     },
     setSelection(selection) {
-      this.$emit('setSelection', selection);
-    },
-  },
-}
+      this.$emit('setselection', selection);
+    }
+  }
+};
 </script>
 
 <style lang="scss">
 @mixin masked() {
-  background-color: var(--v-secondary-lighten3);
-  box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten2);
+  background-color: var(--v-secondary-lighten2);
   font-weight: 300;
   color: var(--v-secondary-base);
 }
@@ -147,7 +167,10 @@ export default {
   table-layout: fixed;
   border-collapse: collapse;
 
-  .key, .metadata, .header, .group {
+  .key,
+  .metadata,
+  .header,
+  .group {
     color: white;
     font-weight: 700;
     text-align: left;
@@ -156,30 +179,74 @@ export default {
   colgroup {
     col {
       &.active {
-        background: linear-gradient(0deg,rgba(161, 213, 255, 0.3),rgba(161, 213, 255, 0.3));
+        background: linear-gradient(
+          0deg,
+          rgba(161, 213, 255, 0.4),
+          rgba(161, 213, 255, 0.4)
+        );
+
+        &.first {
+          background: linear-gradient(
+            90deg,
+            rgb(23, 147, 248) 0px,
+            rgba(161, 213, 255, 0.4) 2px
+          );
+        }
+
+        &.last {
+          background: linear-gradient(
+            90deg,
+            rgba(161, 213, 255, 0.4) 0px,
+            rgba(161, 213, 255, 0.4) calc(100% - 2px),
+            rgb(23, 147, 248) 100%
+          );
+        }
+
+        &.first.last {
+          background: linear-gradient(
+            90deg,
+            rgb(23, 147, 248) 0px,
+            rgba(161, 213, 255, 0.4) 2px,
+            rgba(161, 213, 255, 0.4) calc(100% - 2px),
+            rgb(23, 147, 248) 100%
+          );
+        }
       }
 
-      &.active.key, &.key {
-        background-color:  var(--v-primary-lighten4);
+      &.active.key,
+      &.key,
+      &.active.first.key,
+      &.active.last.key {
+        background-color: var(--v-primary-lighten3);
       }
 
-      &.active.metadata, &.metadata {
-        background-color:  var(--v-accent2-lighten3);
+      &.active.metadata,
+      &.metadata,
+      &.active.first.metadata,
+      &.active.last.metadata {
+        background-color: var(--v-accent2-lighten3);
       }
 
-      &.active.group, &.group {
-        background-color:   var(--v-accent3-lighten3);
+      &.active.group,
+      &.group,
+      &.active.first.group,
+      &.active.last.group {
+        background-color: var(--v-accent3-lighten3);
+      }
+
+      &.masked,
+      &.masked.active,
+      &.masked.active.first,
+      &.masked.active.last {
+        @include masked();
       }
     }
   }
 
   tr {
-    // background-color: #fdfdfd;
-
-    th, td {
-      box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten3);
-      padding: 2px 6px;
-      text-align: center;
+    th,
+    td {
+      padding: 2px 7px;
       white-space: nowrap;
 
       &.control {
@@ -188,87 +255,67 @@ export default {
       }
     }
 
-    &.active.first td {
-      border-top: 2px solid var(--v-secondary-darken3);
-    }
-
-    &.active.last td{
-      border-bottom: 2px solid var(--v-secondary-darken3);
-    }
-
     &.active {
       &.metadata {
         td {
-          box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
+          box-shadow: inset 0 0 0 0.5px rgba(161, 213, 255, 0.15) !important;
         }
       }
     }
 
-    &.active td,
-    td.active {
-      background: linear-gradient(0deg,rgba(161, 213, 255, 0.2),rgba(161, 213, 255, 0.2));
-      box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.3);
+    &.active {
+      background: linear-gradient(
+        0deg,
+        rgba(161, 213, 255, 0.4),
+        rgba(161, 213, 255, 0.4)
+      );
 
-      &.group,
-      &.key,
-      &.metadata,
-      &.masked {
-        box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
+      &.first {
+        background: linear-gradient(
+          180deg,
+          rgb(23, 147, 248) 0px,
+          rgba(161, 213, 255, 0.4) 2px
+        );
+      }
+
+      &.last {
+        background: linear-gradient(
+          180deg,
+          rgba(161, 213, 255, 0.4) 0px,
+          rgba(161, 213, 255, 0.4) calc(100% - 2px),
+          rgb(23, 147, 248) 100%
+        );
+      }
+
+      &.first.last {
+        background: linear-gradient(
+          180deg,
+          rgb(23, 147, 248) 0px,
+          rgba(161, 213, 255, 0.4) 2px,
+          rgba(161, 213, 255, 0.4) calc(100% - 2px),
+          rgb(23, 147, 248) 100%
+        );
       }
     }
   }
 
   tr.datarow {
-    &.header {
-      td {
-        background-color: var(--v-accent-lighten1);
-        box-shadow: inset 0 0 0 .5px var(--v-accent-base);
-
-        &.active {
-          color: white;
-        }
-        &.masked {
-          color: var(--v-secondary-base);
-        }
-      }
-    }
-
-    &.metadata {
-      td {
-        background-color: var(--v-accent2-lighten2);
-        box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
-      }
-    }
+    text-align: left;
 
     &.header,
-    &.metadata {
-      td.key, td.metadata, td.group {
-        @include masked();
-      }
+    &.header.active {
+      background-color: var(--v-accent-lighten1);
     }
 
-    td {
-      &.key {
-        background-color: var(--v-primary-base);
-        box-shadow: inset 0 0 0 .5px var(--v-primary-darken1);
-      }
-
-      &.metadata, {
-        background-color: var(--v-accent2-lighten2);
-        box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
-      }
-
-      &.group {
-        background-color: var(--v-accent3-lighten1);
-        box-shadow: inset 0 0 0 .5px var(--v-accent3-base);
-      }
+    &.metadata,
+    &.metadata.active {
+      background-color: var(--v-accent2-lighten2);
     }
   }
 
   tr.datarow {
-    &.masked td,
-    td.masked,
-    th.masked {
+    &.masked,
+    &.masked.active {
       @include masked();
     }
   }

--- a/web/src/components/DataTable.vue
+++ b/web/src/components/DataTable.vue
@@ -1,12 +1,23 @@
 <template lang="pug">
-table.cleanup-table(v-data-table="{ dataset, id, activeClasses, setSelection, selectedRanges }")
+table.cleanup-table(v-data-table="{ dataset, id, activeClasses, setSelection, selectedRanges, icons: $vuetify.icons }")
 </template>
 
 <script>
 import { base26Converter } from '@/utils';
+import {
+  defaultRowOption,
+  defaultColOption,
+} from '@/utils/constants';
+
+function getIcon(iconType, icons) {
+  const el = document.createElement('i');
+  el.classList.add(...['v-icon', 'small', 'mdi', 'theme--light', icons[iconType]]);
+  el.style.fontSize = '16px';
+  return el;
+}
 
 function updateTable(el, binding) {
-  const { dataset, id, activeClasses, setSelection } = binding.value;
+  const { dataset, id, activeClasses, setSelection, icons } = binding.value;
   const colgroup = el.getElementsByTagName('colgroup')[0];
   const body = el.getElementsByTagName('tbody')[0];
   const columns = colgroup.children;
@@ -24,7 +35,8 @@ function updateTable(el, binding) {
       'measurement'
     );
     col.classList.add(...activeClasses(index, 'column'));
-    col.classList.add(dataset.column.labels[index]);
+    const colType = dataset.column.labels[index];
+    col.classList.add(colType);
   }
 
   for (let index = 0; index < rows.length; index += 1) {
@@ -47,7 +59,7 @@ function renderTable(el, binding) {
   while (el.firstChild) {
     el.removeChild(el.firstChild);
   }
-  const { dataset, id, activeClasses, setSelection } = binding.value;
+  const { dataset, id, activeClasses, setSelection, icons } = binding.value;
   const thead = document.createElement('thead');
   const colgroup = document.createElement('colgroup');
   const tr0 = document.createElement('tr');
@@ -60,13 +72,18 @@ function renderTable(el, binding) {
     const coln = document.createElement('col');
     const thn = document.createElement('th');
     const span = document.createElement('span');
-    span.innerText = base26Converter(index + 1);
+    const colType = dataset.column.labels[index];
     thn.onclick = event => {
       setSelection({ key: id, event, axis: 'column', idx: index });
     };
+    if (colType !== defaultColOption) {
+      span.appendChild(getIcon(colType, icons));
+    } else {
+      span.innerText = base26Converter(index + 1);
+    }
     thn.classList.add('control', 'px-2');
     coln.classList.add(...activeClasses(index, 'column'));
-    coln.classList.add(dataset.column.labels[index]);
+    coln.classList.add(colType);
     thn.appendChild(span);
     tr0.appendChild(thn);
     colgroup.appendChild(coln);
@@ -76,11 +93,16 @@ function renderTable(el, binding) {
   const tbody = document.createElement('tbody');
   dataset.sourcerows.forEach((row, index) => {
     const trn = document.createElement('tr');
+    const rowType = dataset.row.labels[index]
     trn.classList.add(...['datarow'].concat(activeClasses(index, 'row')));
-    trn.classList.add(dataset.row.labels[index]);
+    trn.classList.add(rowType);
     tbody.appendChild(trn);
     const td = document.createElement('td');
-    td.innerText = index + 1;
+    if (rowType !== defaultRowOption) {
+      td.appendChild(getIcon(rowType, icons));
+    } else {
+      td.innerText = base26Converter(index + 1);
+    }
     td.classList.add('control');
     td.onclick = event => {
       setSelection({ key: id, event, axis: 'row', idx: index });

--- a/web/src/components/DataTable.vue
+++ b/web/src/components/DataTable.vue
@@ -20,6 +20,7 @@ function updateTable(el, binding) {
   const { dataset, id, activeClasses, setSelection, icons } = binding.value;
   const colgroup = el.getElementsByTagName('colgroup')[0];
   const body = el.getElementsByTagName('tbody')[0];
+  const headrow = el.getElementsByTagName('thead')[0].children[0];
   const columns = colgroup.children;
   const rows = body.children;
   for (let index = 0; index < columns.length - 1; index += 1) {
@@ -37,6 +38,14 @@ function updateTable(el, binding) {
     col.classList.add(...activeClasses(index, 'column'));
     const colType = dataset.column.labels[index];
     col.classList.add(colType);
+
+    const colHeader = headrow.children[index + 1];
+    colHeader.removeChild(colHeader.firstChild);
+    if (colType !== defaultColOption) {
+      colHeader.appendChild(getIcon(colType, icons));
+    } else {
+      colHeader.innerText = base26Converter(index + 1);
+    }
   }
 
   for (let index = 0; index < rows.length; index += 1) {
@@ -51,7 +60,16 @@ function updateTable(el, binding) {
       'sample'
     );
     row.classList.add(...activeClasses(index, 'row'));
-    row.classList.add(dataset.row.labels[index]);
+    const rowType = dataset.row.labels[index];
+    row.classList.add(rowType);
+
+    const rowHeader = row.children[0];
+    rowHeader.removeChild(rowHeader.firstChild);
+    if (rowType !== defaultRowOption) {
+      rowHeader.appendChild(getIcon(rowType, icons));
+    } else {
+      rowHeader.innerText = index + 1;
+    }
   }
 }
 
@@ -101,7 +119,7 @@ function renderTable(el, binding) {
     if (rowType !== defaultRowOption) {
       td.appendChild(getIcon(rowType, icons));
     } else {
-      td.innerText = base26Converter(index + 1);
+      td.innerText = index + 1;
     }
     td.classList.add('control');
     td.onclick = event => {

--- a/web/src/components/DataTable.vue
+++ b/web/src/components/DataTable.vue
@@ -1,0 +1,276 @@
+<template lang="pug">
+table.cleanup-table(v-data-table="{ dataset, id, activeClasses, setSelection, selectedRanges }")
+</template>
+
+<script>
+import { base26Converter } from '@/utils';
+
+function updateTable(el, binding) {
+  const { dataset, id, activeClasses, setSelection } = binding.value;
+  const colgroup = el.getElementsByTagName('colgroup')[0];
+  const body = el.getElementsByTagName('tbody')[0];
+  const columns = colgroup.children;
+  const rows = body.children;
+  for(let index = 0; index < (columns.length - 1); index += 1) {
+    const col = columns[index + 1]; // Account for 0th being empty
+    col.classList.remove('first', 'last', 'active', 'key', 'group', 'metadata', 'masked', 'measurement');
+    col.classList.add(...activeClasses(index, 'column'));
+    col.classList.add(dataset.column.labels[index]);
+  }
+
+  for(let index = 0; index < (rows.length); index += 1) {
+    const row = rows[index];
+    row.classList.remove('first', 'last', 'active', 'header', 'metadata', 'masked', 'sample');
+    row.classList.add(...activeClasses(index, 'row'));
+    row.classList.add(dataset.row.labels[index]);
+  }
+}
+
+function renderTable(el, binding) {
+  while(el.firstChild) {
+    el.removeChild(el.firstChild);
+  }
+  const { dataset, id, activeClasses, setSelection } = binding.value;
+  const thead = document.createElement('thead');
+  const colgroup = document.createElement('colgroup');
+  const tr0 = document.createElement('tr');
+  const th0 = document.createElement('th');
+  const col0 = document.createElement('col');
+  tr0.appendChild(th0);
+  colgroup.appendChild(col0);
+
+  dataset.column.labels.forEach((col, index) => {
+    const coln = document.createElement('col');
+    const thn = document.createElement('th');
+    const span = document.createElement('span');
+    span.innerText = base26Converter(index + 1);
+    thn.onclick = (event) => {
+      setSelection({ key: id, event, axis: 'column', idx: index });
+    }
+    thn.classList.add('control', 'px-2')
+    coln.classList.add(...activeClasses(index, 'column'));
+    coln.classList.add(dataset.column.labels[index]);
+    thn.appendChild(span);
+    tr0.appendChild(thn);
+    colgroup.appendChild(coln);
+  });
+  thead.appendChild(tr0);
+  
+  const tbody = document.createElement('tbody');
+  dataset.sourcerows.forEach((row, index) => {
+    const trn = document.createElement('tr');
+    trn.classList.add(...['datarow'].concat(activeClasses(index, 'row')));
+    trn.classList.add(dataset.row.labels[index]);
+    tbody.appendChild(trn);
+    const td = document.createElement('td');
+    td.innerText = index + 1;
+    td.classList.add('control');
+    td.onclick = (event) => {
+      setSelection({ key: id, event, axis: 'row', idx: index });
+    }
+    trn.appendChild(td);
+    row.forEach((col, idx2) => {
+      const tdn = document.createElement('td');
+      tdn.innerText = col;
+      trn.appendChild(tdn);
+      tdn.classList.add('row');
+    });
+  });
+
+  el.appendChild(colgroup);
+  el.appendChild(thead);
+  el.appendChild(tbody);
+}
+
+export default {
+  props: {
+    dataset: {
+      type: Object,
+      required: true,
+    },
+    id: {
+      type: String,
+      required: true,
+    },
+    selected: {
+      type: Object,
+      required: true,
+    },
+  },
+  directives: {
+    dataTable: {
+      inserted: renderTable,
+      update: updateTable,
+    }
+  },
+  computed: {
+    selectedRanges() { return this.selected.ranges; },
+    selectedType() { return this.selected.type; },
+  },
+  methods: {
+    activeClasses(index, axisName) {
+      if (axisName === this.selected.type) {
+        const ranges = this.selectedRanges;
+        const includes = ranges.includes(index);
+        const classList = [];
+        if (includes.member) {
+          classList.push('active');
+        }
+        if (includes.first) {
+          classList.push('first');
+        }
+        if (includes.last) {
+          classList.push('last');
+        }
+        return classList;
+      }
+      return [];
+    },
+    setSelection(selection) {
+      this.$emit('setSelection', selection);
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+@mixin masked() {
+  background-color: var(--v-secondary-lighten3);
+  box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten2);
+  font-weight: 300;
+  color: var(--v-secondary-base);
+}
+
+.cleanup-table {
+  border-spacing: 0px;
+  user-select: none;
+  table-layout: fixed;
+  border-collapse: collapse;
+
+  .key, .metadata, .header, .group {
+    color: white;
+    font-weight: 700;
+    text-align: left;
+  }
+
+  colgroup {
+    col {
+      &.active {
+        background: linear-gradient(0deg,rgba(161, 213, 255, 0.3),rgba(161, 213, 255, 0.3));
+      }
+
+      &.active.key, &.key {
+        background-color:  var(--v-primary-lighten4);
+      }
+
+      &.active.metadata, &.metadata {
+        background-color:  var(--v-accent2-lighten3);
+      }
+
+      &.active.group, &.group {
+        background-color:   var(--v-accent3-lighten3);
+      }
+    }
+  }
+
+  tr {
+    // background-color: #fdfdfd;
+
+    th, td {
+      box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten3);
+      padding: 2px 6px;
+      text-align: center;
+      white-space: nowrap;
+
+      &.control {
+        cursor: pointer;
+        font-weight: 300;
+      }
+    }
+
+    &.active.first td {
+      border-top: 2px solid var(--v-secondary-darken3);
+    }
+
+    &.active.last td{
+      border-bottom: 2px solid var(--v-secondary-darken3);
+    }
+
+    &.active {
+      &.metadata {
+        td {
+          box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
+        }
+      }
+    }
+
+    &.active td,
+    td.active {
+      background: linear-gradient(0deg,rgba(161, 213, 255, 0.2),rgba(161, 213, 255, 0.2));
+      box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.3);
+
+      &.group,
+      &.key,
+      &.metadata,
+      &.masked {
+        box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
+      }
+    }
+  }
+
+  tr.datarow {
+    &.header {
+      td {
+        background-color: var(--v-accent-lighten1);
+        box-shadow: inset 0 0 0 .5px var(--v-accent-base);
+
+        &.active {
+          color: white;
+        }
+        &.masked {
+          color: var(--v-secondary-base);
+        }
+      }
+    }
+
+    &.metadata {
+      td {
+        background-color: var(--v-accent2-lighten2);
+        box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
+      }
+    }
+
+    &.header,
+    &.metadata {
+      td.key, td.metadata, td.group {
+        @include masked();
+      }
+    }
+
+    td {
+      &.key {
+        background-color: var(--v-primary-base);
+        box-shadow: inset 0 0 0 .5px var(--v-primary-darken1);
+      }
+
+      &.metadata, {
+        background-color: var(--v-accent2-lighten2);
+        box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
+      }
+
+      &.group {
+        background-color: var(--v-accent3-lighten1);
+        box-shadow: inset 0 0 0 .5px var(--v-accent3-base);
+      }
+    }
+  }
+
+  tr.datarow {
+    &.masked td,
+    td.masked,
+    th.masked {
+      @include masked();
+    }
+  }
+}
+</style>

--- a/web/src/components/DataTable.vue
+++ b/web/src/components/DataTable.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-table.cleanup-table(v-data-table="{ dataset, id, activeClasses, setSelection, selectedRanges, icons: $vuetify.icons }")
+table.cleanup-table(v-data-table="bind")
 </template>
 
 <script>
@@ -17,7 +17,9 @@ function getIcon(iconType, icons) {
 }
 
 function updateTable(el, binding) {
-  const { dataset, id, activeClasses, setSelection, icons } = binding.value;
+  const {
+    dataset, activeClasses, icons,
+  } = binding.value;
   const colgroup = el.getElementsByTagName('colgroup')[0];
   const body = el.getElementsByTagName('tbody')[0];
   const headrow = el.getElementsByTagName('thead')[0].children[0];
@@ -33,7 +35,7 @@ function updateTable(el, binding) {
       'group',
       'metadata',
       'masked',
-      'measurement'
+      'measurement',
     );
     col.classList.add(...activeClasses(index, 'column'));
     const colType = dataset.column.labels[index];
@@ -57,7 +59,7 @@ function updateTable(el, binding) {
       'header',
       'metadata',
       'masked',
-      'sample'
+      'sample',
     );
     row.classList.add(...activeClasses(index, 'row'));
     const rowType = dataset.row.labels[index];
@@ -77,7 +79,9 @@ function renderTable(el, binding) {
   while (el.firstChild) {
     el.removeChild(el.firstChild);
   }
-  const { dataset, id, activeClasses, setSelection, icons } = binding.value;
+  const {
+    dataset, id, activeClasses, setSelection, icons,
+  } = binding.value;
   const thead = document.createElement('thead');
   const colgroup = document.createElement('colgroup');
   const tr0 = document.createElement('tr');
@@ -91,8 +95,10 @@ function renderTable(el, binding) {
     const thn = document.createElement('th');
     const span = document.createElement('span');
     const colType = dataset.column.labels[index];
-    thn.onclick = event => {
-      setSelection({ key: id, event, axis: 'column', idx: index });
+    thn.onclick = (event) => {
+      setSelection({
+        key: id, event, axis: 'column', idx: index,
+      });
     };
     if (colType !== defaultColOption) {
       span.appendChild(getIcon(colType, icons));
@@ -111,7 +117,7 @@ function renderTable(el, binding) {
   const tbody = document.createElement('tbody');
   dataset.sourcerows.forEach((row, index) => {
     const trn = document.createElement('tr');
-    const rowType = dataset.row.labels[index]
+    const rowType = dataset.row.labels[index];
     trn.classList.add(...['datarow'].concat(activeClasses(index, 'row')));
     trn.classList.add(rowType);
     tbody.appendChild(trn);
@@ -122,11 +128,13 @@ function renderTable(el, binding) {
       td.innerText = index + 1;
     }
     td.classList.add('control');
-    td.onclick = event => {
-      setSelection({ key: id, event, axis: 'row', idx: index });
+    td.onclick = (event) => {
+      setSelection({
+        key: id, event, axis: 'row', idx: index,
+      });
     };
     trn.appendChild(td);
-    row.forEach((col, idx2) => {
+    row.forEach((col) => {
       const tdn = document.createElement('td');
       tdn.innerText = col;
       trn.appendChild(tdn);
@@ -140,25 +148,25 @@ function renderTable(el, binding) {
 }
 
 export default {
-  props: {
-    dataset: {
-      type: Object,
-      required: true
-    },
-    id: {
-      type: String,
-      required: true
-    },
-    selected: {
-      type: Object,
-      required: true
-    }
-  },
   directives: {
     dataTable: {
       inserted: renderTable,
-      update: updateTable
-    }
+      update: updateTable,
+    },
+  },
+  props: {
+    dataset: {
+      type: Object,
+      required: true,
+    },
+    id: {
+      type: String,
+      required: true,
+    },
+    selected: {
+      type: Object,
+      required: true,
+    },
   },
   computed: {
     selectedRanges() {
@@ -166,7 +174,16 @@ export default {
     },
     selectedType() {
       return this.selected.type;
-    }
+    },
+    bind() {
+      const {
+        dataset, id, activeClasses, setSelection, selectedRanges,
+      } = this;
+      const { icons } = this.$vuetify;
+      return {
+        dataset, id, activeClasses, setSelection, selectedRanges, icons,
+      };
+    },
   },
   methods: {
     activeClasses(index, axisName) {
@@ -189,8 +206,8 @@ export default {
     },
     setSelection(selection) {
       this.$emit('setselection', selection);
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -95,7 +95,8 @@ v-layout.pretreatment-component(row, fill-height)
               v-list-tile-title.pl-2
                 v-icon.pr-1.middle {{ $vuetify.icons.bubbles }}
                 | Transform Table
-  router-view
+  keep-alive
+    router-view
 </template>
 
 <style lang="scss">


### PR DESCRIPTION
This is a  proof of concept fix for #148.  There are a large number of sacrifices involved, so I need help deciding what to prioritize.

![Screenshot_20190715_113059](https://user-images.githubusercontent.com/4214172/61228309-08b7b900-a6f4-11e9-89ac-e96b96547f9e.png)

This is the highest-performance version I could get, and it's perfectly responsive (20-30ms latency between clicks and style changes on my machine).

Some info:

* Swapped cell-level styles on columns for colgroups, dropping the computation cost from MxN to M+N for updates.  Insert is obviously still MxN.  This has a large flexibility cost, because colgroups can only set style [in limited ways](https://www.w3.org/TR/CSS21/tables.html#columns)
* I've dropped borders around the selected region, and around different types of columns.  Changing cell borders forces a table width recomputation and the whole page layout has to recompute at great cost.
* It will be much more challenging now to make the primary key clickable.  I can still do it efficiently, but I consider that lower priority priority.

The nastiest parts here are
* how the table borders look inside highlighted columns.  For example, the grey borders inside the pink metadata columns.  There's just nothing I'm aware of we can do about this: we would have to trade about a second of page unresponsiveness to make that better in the worst case.  
* That I can't set many kinds of column-level styles anymore.  Notice the rows text are white but the columns are black.  colgroups don't let you set cell styles.
* That now, selected columns and rows that already have some formatting are super hard to distinguish.  Example below: the header row is highlighted, but you can't tell.

![Screenshot_20190715_114038](https://user-images.githubusercontent.com/4214172/61229044-6dbfde80-a6f5-11e9-85b9-2af3aefc5f71.png)


cc @jtomeck @jeffbaumes @jbeezley all your thoughts and suggestions are welcome.

fixes #148