### PR TITLE
NxM manual update

### DIFF
--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -12,10 +12,12 @@ import {
 } from '@/utils/constants';
 import { base26Converter } from '@/utils';
 import SaveStatus from '@/components/SaveStatus.vue';
+import CleanupTable from '@/components/Table.vue';
 
 export default {
   components: {
     SaveStatus,
+    CleanupTable,
   },
   props: {
     id: {
@@ -84,17 +86,6 @@ export default {
         options: this.imputation,
       });
     },
-    activeClasses(index, axisName) {
-      if (axisName === this.selected.type) {
-        const includes = this.selected.ranges.includes(index);
-        return {
-          active: includes.member,
-          first: includes.first,
-          last: includes.last,
-        };
-      }
-      return {};
-    },
   },
 };
 </script>
@@ -157,40 +148,10 @@ v-layout.cleanup-wrapper(row)
       v-icon {{ $vuetify.icons.download }}
 
     .overflow-auto
-      table.cleanup-table
-
-        thead
-          tr
-            th
-            th.control.px-2(
-                v-for="(col, index) in dataset.column.labels",
-                :class="activeClasses(index, 'column')",
-                @click="setSelection({ key: id, event: $event, axis: 'column', idx: index })")
-              span(v-if="col === defaultColOption") {{ base26Converter(index + 1) }}
-              v-icon(v-else, small) {{ $vuetify.icons[col] }}
-
-        tbody
-          tr.datarow(v-for="(row, index) in dataset.sourcerows",
-              :key="`${index}${row[0]}`",
-              :class="{[dataset.row.labels[index]]: true, ...activeClasses(index, 'row')}")
-            td.control.px-2(
-                @click="setSelection({ key: id, event: $event, axis: 'row', idx: index })")
-              span(v-if="dataset.row.labels[index] === defaultRowOption") {{ index + 1 }}
-              v-icon(v-else, small) {{ $vuetify.icons[dataset.row.labels[index]] }}
-            td.px-2.row(
-                v-for="(col, idx2) in row",
-                :class="{[dataset.column.labels[idx2]]: true, ...activeClasses(idx2, 'column')}",
-                :key="`${index}.${idx2}`") {{ col }}
+      cleanup-table(v-bind="{ dataset, id, selected }", @setSelection="setSelection")
 </template>
 
 <style lang="scss">
-@mixin masked() {
-  background-color: var(--v-secondary-lighten3);
-  box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten2);
-  font-weight: 300;
-  color: var(--v-secondary-base);
-}
-
 .cleanup-wrapper {
   width: 100%;
 
@@ -230,134 +191,6 @@ v-layout.cleanup-wrapper(row)
       padding: 2px;
       border-radius: 3px;
       margin: 4px;
-    }
-  }
-
-  .cleanup-table {
-    border-spacing: 0px;
-    user-select: none;
-
-    .key, .metadata, .header, .group {
-      color: white;
-      font-weight: 700;
-      text-align: left;
-    }
-
-    tr {
-      background-color: #fdfdfd;
-
-      th, td {
-        box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten3);
-        padding: 2px;
-        text-align: center;
-        white-space: nowrap;
-
-        &.control {
-          cursor: pointer;
-          font-weight: 300;
-        }
-      }
-
-      td.active, th.active {
-        &.first {
-          border-left: 2px solid var(--v-secondary-darken3);
-        }
-
-        &.last {
-          border-right: 2px solid var(--v-secondary-darken3);
-        }
-      }
-
-      &.active.first td {
-        border-top: 2px solid var(--v-secondary-darken3);
-      }
-
-      &.active.last td{
-        border-bottom: 2px solid var(--v-secondary-darken3);
-      }
-
-      &.active {
-        &.metadata {
-          td {
-            box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
-          }
-        }
-      }
-
-      &.active td,
-      td.active {
-        background: linear-gradient(0deg,rgba(161, 213, 255, 0.2),rgba(161, 213, 255, 0.2));
-        box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.3);
-
-        &.group,
-        &.key,
-        &.metadata,
-        &.masked {
-          box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
-        }
-      }
-    }
-
-    tr.datarow {
-      &.header {
-        td {
-          background-color: var(--v-accent-lighten1);
-          box-shadow: inset 0 0 0 .5px var(--v-accent-base);
-
-          &.active {
-            color: white;
-
-            &.first{
-              border-left: 2px solid var(--v-secondary-darken3);
-            }
-            &.last {
-              border-right: 2px solid var(--v-secondary-darken3);
-            }
-          }
-          &.masked {
-            color: var(--v-secondary-base);
-          }
-        }
-      }
-
-      &.metadata {
-        td {
-          background-color: var(--v-accent2-lighten2);
-          box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
-        }
-      }
-
-      &.header,
-      &.metadata {
-        td.key, td.metadata, td.group {
-          @include masked();
-        }
-      }
-
-      td {
-        &.key {
-          background-color: var(--v-primary-base);
-          box-shadow: inset 0 0 0 .5px var(--v-primary-darken1);
-        }
-
-        &.metadata, {
-          background-color: var(--v-accent2-lighten2);
-          box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
-        }
-
-        &.group {
-          background-color: var(--v-accent3-lighten1);
-          box-shadow: inset 0 0 0 .5px var(--v-accent3-base);
-        }
-      }
-    }
-
-    tr.datarow {
-      &.masked td,
-      td.masked,
-      th.masked {
-        @include masked();
-      }
     }
   }
 }

--- a/web/src/components/Pretreatment.vue
+++ b/web/src/components/Pretreatment.vue
@@ -95,7 +95,8 @@ v-layout.pretreatment-component(row, fill-height)
               v-list-tile-title.pl-2
                 v-icon.pr-1.middle {{ $vuetify.icons.bubbles }}
                 | Transform Table
-  router-view
+  keep-alive
+    router-view
 </template>
 
 <style lang="scss">

--- a/web/src/components/Table.vue
+++ b/web/src/components/Table.vue
@@ -1,0 +1,292 @@
+<template lang="pug">
+table.cleanup-table(v-data-table="{ dataset, id, activeClasses, setSelection, selectedRanges }")
+</template>
+
+<script>
+import { base26Converter } from '@/utils';
+
+
+function updateTable(el, binding) {
+
+  const { dataset, id, activeClasses, setSelection } = binding.value;
+  const colLabels = dataset.column.labels;
+  const rowLabels = dataset.row.labels;
+  // const colgroup = el.getElementsByTagName('colgroup')[0];
+  const head = el.getElementsByTagName('thead')[0];
+  const body = el.getElementsByTagName('tbody')[0];
+  // const columns = colgroup.children;
+  const headers = head.children[0].children;  
+  const rows = body.children;
+
+  for(let index = 0; index < (headers.length - 1); index += 1) {
+    const col = headers[index + 1]; // Account for 0th being empty
+    col.classList.remove('first', 'last', 'active', 'key', 'group', 'metadata', 'masked', 'measurement');
+    col.classList.add(...activeClasses(index, 'column'));
+    col.classList.add(colLabels[index]);
+  }
+
+
+  for(let index = 0; index < (rows.length); index += 1) {
+    const row = rows[index];
+    row.classList.remove('first', 'last', 'active', 'header', 'metadata', 'masked', 'sample');
+    row.classList.add(...activeClasses(index, 'row'));
+    row.classList.add(rowLabels[index]);
+
+    const columns = row.children;
+    for(let index = 0; index < (columns.length - 1); index += 1) {
+      const col = columns[index + 1];
+      col.classList.remove('first', 'last', 'active', 'key', 'group', 'metadata', 'masked', 'measurement');
+      col.classList.add(...activeClasses(index, 'column'));
+      col.classList.add(colLabels[index]);
+    }
+  }
+}
+
+function renderTable(el, binding) {
+  while(el.firstChild) {
+    el.removeChild(el.firstChild);
+  }
+
+  const { dataset, id, activeClasses, setSelection } = binding.value;
+  const thead = document.createElement('thead');
+  // const colgroup = document.createElement('colgroup');
+  const tr0 = document.createElement('tr');
+  const th0 = document.createElement('th');
+  const col0 = document.createElement('col');
+  tr0.appendChild(th0);
+  // colgroup.appendChild(col0);
+
+  dataset.column.labels.forEach((col, index) => {
+    // const coln = document.createElement('col');
+    const thn = document.createElement('th');
+    const span = document.createElement('span');
+    span.innerText = base26Converter(index + 1);
+    thn.onclick = (event) => {
+      setSelection({ key: id, event, axis: 'column', idx: index });
+    }
+    thn.classList.add('control', 'px-2')
+    // coln.classList.add(...activeClasses(index, 'column'));
+    // coln.classList.add(dataset.column.labels[index]);
+    thn.classList.add(...activeClasses(index, 'column'));
+    
+    thn.appendChild(span);
+    tr0.appendChild(thn);
+    // colgroup.appendChild(coln);
+  });
+  thead.appendChild(tr0);
+  
+  const tbody = document.createElement('tbody');
+  dataset.sourcerows.forEach((row, index) => {
+    const trn = document.createElement('tr');
+    trn.classList.add(...['datarow'].concat(activeClasses(index, 'row')));
+    trn.classList.add(dataset.row.labels[index]);
+    tbody.appendChild(trn);
+    const td = document.createElement('td');
+    td.innerText = index + 1;
+    td.classList.add('control');
+    td.onclick = (event) => {
+      setSelection({ key: id, event, axis: 'row', idx: index });
+    }
+    trn.appendChild(td);
+    row.forEach((col, idx2) => {
+      const tdn = document.createElement('td');
+      tdn.innerText = col;
+      trn.appendChild(tdn);
+      tdn.classList.add('row');
+      tdn.classList.add(dataset.column.labels[idx2]);
+      tdn.classList.add(...activeClasses(idx2, 'column'));
+    });
+  });
+
+  // el.appendChild(colgroup);
+  el.appendChild(thead);
+  el.appendChild(tbody);
+}
+
+export default {
+  props: {
+    dataset: {
+      type: Object,
+      required: true,
+    },
+    id: {
+      type: String,
+      required: true,
+    },
+    selected: {
+      type: Object,
+      required: true,
+    },
+  },
+  directives: {
+    dataTable: {
+      inserted: renderTable,
+      update: updateTable,
+    }
+  },
+  computed: {
+    selectedRanges() { return this.selected.ranges; },
+    selectedType() { return this.selected.type; },
+  },
+  methods: {
+    activeClasses(index, axisName) {
+      if (axisName === this.selected.type) {
+        const ranges = this.selectedRanges;
+        const includes = ranges.includes(index);
+        const classList = [];
+        if (includes.member) {
+          classList.push('active');
+        }
+        if (includes.first) {
+          classList.push('first');
+        }
+        if (includes.last) {
+          classList.push('last');
+        }
+        return classList;
+      }
+      return [];
+    },
+    setSelection(selection) {
+      this.$emit('setSelection', selection);
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+@mixin masked() {
+  background-color: var(--v-secondary-lighten3);
+  box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten2);
+  font-weight: 300;
+  color: var(--v-secondary-base);
+}
+
+.cleanup-table {
+  border-spacing: 0px;
+  user-select: none;
+
+  .key, .metadata, .header, .group {
+    color: white;
+    font-weight: 700;
+    text-align: left;
+  }
+
+  tr {
+    background-color: #fdfdfd;
+
+    th, td {
+      box-shadow: inset 0 0 0 .5px var(--v-secondary-lighten3);
+      padding: 2px;
+      text-align: center;
+      white-space: nowrap;
+
+      &.control {
+        cursor: pointer;
+        font-weight: 300;
+      }
+    }
+
+    td.active, th.active {
+      &.first {
+        border-left: 2px solid var(--v-secondary-darken3);
+      }
+
+      &.last {
+        border-right: 2px solid var(--v-secondary-darken3);
+      }
+    }
+
+    &.active.first td {
+      border-top: 2px solid var(--v-secondary-darken3);
+    }
+
+    &.active.last td{
+      border-bottom: 2px solid var(--v-secondary-darken3);
+    }
+
+    &.active {
+      &.metadata {
+        td {
+          box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
+        }
+      }
+    }
+
+    &.active td,
+    td.active {
+      background: linear-gradient(0deg,rgba(161, 213, 255, 0.2),rgba(161, 213, 255, 0.2));
+      box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.3);
+
+      &.group,
+      &.key,
+      &.metadata,
+      &.masked {
+        box-shadow: inset 0 0 0 .5px rgba(161, 213, 255, 0.15) !important;
+      }
+    }
+  }
+
+  tr.datarow {
+    &.header {
+      td {
+        background-color: var(--v-accent-lighten1);
+        box-shadow: inset 0 0 0 .5px var(--v-accent-base);
+
+        &.active {
+          color: white;
+
+          &.first{
+            // border-left: 2px solid var(--v-secondary-darken3);
+          }
+          &.last {
+            // border-right: 2px solid var(--v-secondary-darken3);
+          }
+        }
+        &.masked {
+          color: var(--v-secondary-base);
+        }
+      }
+    }
+
+    &.metadata {
+      td {
+        background-color: var(--v-accent2-lighten2);
+        box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
+      }
+    }
+
+    &.header,
+    &.metadata {
+      td.key, td.metadata, td.group {
+        @include masked();
+      }
+    }
+
+    td {
+      &.key {
+        background-color: var(--v-primary-base);
+        box-shadow: inset 0 0 0 .5px var(--v-primary-darken1);
+      }
+
+      &.metadata, {
+        background-color: var(--v-accent2-lighten2);
+        box-shadow: inset 0 0 0 .5px var(--v-accent2-lighten1);
+      }
+
+      &.group {
+        background-color: var(--v-accent3-lighten1);
+        box-shadow: inset 0 0 0 .5px var(--v-accent3-base);
+      }
+    }
+  }
+
+  tr.datarow {
+    &.masked td,
+    td.masked,
+    th.masked {
+      @include masked();
+    }
+  }
+}
+</style>

--- a/web/src/utils/rangelist.js
+++ b/web/src/utils/rangelist.js
@@ -14,11 +14,12 @@ export default class RangeList {
   _find(el) {
     let lowIndex = 0;
     let highIndex = this.members.length - 1;
+    const members = this.members;
     while (lowIndex <= highIndex) {
       const midIndex = Math.floor((lowIndex + highIndex) / 2);
-      if (this.members[midIndex] === el) {
+      if (members[midIndex] === el) {
         return midIndex;
-      } if (this.members[midIndex] < el) {
+      } if (members[midIndex] < el) {
         lowIndex = midIndex + 1;
       } else {
         highIndex = midIndex - 1;
@@ -39,12 +40,13 @@ export default class RangeList {
       nin = nout;
       nout = tmp;
     }
+    const members = this.members;
     for (let i = nin; i <= nout; i += 1) {
-      if (this.members.indexOf(i) === -1) {
+      if (members.indexOf(i) === -1) {
         this.members.push(i);
       }
     }
-    this.members = this.members.sort((j, k) => j - k);
+    this.members = members.sort((j, k) => j - k);
   }
 
   /**
@@ -54,12 +56,13 @@ export default class RangeList {
    */
   includes(a) {
     const foundIndex = this._find(a);
+    const members = this.members;
     if (foundIndex !== null) {
       const first = (foundIndex === 0)
-          || (this.members[foundIndex - 1] !== a - 1);
-      const last = (foundIndex === this.members.length - 1)
-          || (this.members[foundIndex + 1] !== a + 1);
-      return { member: true, first, last };
+          || (members[foundIndex - 1] !== a - 1);
+      const last = (foundIndex === members.length - 1)
+          || (members[foundIndex + 1] !== a + 1);
+      return { member: true, first, last };f
     }
     return { member: false };
   }


### PR DESCRIPTION
This PR rivals #154 to fix #148 but is much slower.  The benefit is it looks identical and drops the compute time for the same large CSV from 1800ms second updates to  800ms updates.

I've also encountered a [fascinating bug in Vue](https://github.com/vuejs/vue/issues/8728) that has yet to be patched.  I managed to get a 30% speedup by changing my access pattern:

```js
// before
this.nested.array[index]

// after
const arr = this.nested.array;
array[index]; 
```

Note that in this iteration, I am still reading from reactive properties. 

@matthewma7 suggested in #148 that part of cost may come from turning my response data into observables.  Indeed, this process is costly but still takes <1s and only happens once. After seeing the performance issues with `reactiveGetter`, I tried extracting bits from vuex to prevent reactivity, but I only got another 25% boost -- still quite slow to a user.

At this point, I believe I've explored all the sane options for keeping the cleanup table similar to what @jtomeck has designed.