### PR TITLE
Add fast column/row label changes

### DIFF
--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -326,6 +326,9 @@ class CSVFileSchema(BaseSchema):
             if data.get(key) is not None:
                 return data[key].to_csv()
 
+        if 'table' not in data:
+            return data
+
         data['table'] = data['table'].to_csv(header=False, index=False)
         data['measurement_table'] = get_csv('measurement_table')
         data['measurement_metadata'] = get_csv('measurement_metadata')

--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -247,6 +247,7 @@ def get_column(csv_id, column_index):
 def batch_modify_label(csv_id):
     csv_file = CSVFile.query.get_or_404(csv_id)
     args = modify_label_list_schema.load(request.json or {})
+    row_column_dump_schema = CSVFileSchema(only=['rows', 'columns'])
 
     for change in args['changes']:
         index = change['index']
@@ -273,7 +274,7 @@ def batch_modify_label(csv_id):
 
     try:
         db.session.commit()
-        return jsonify(modify_label_list_schema.dump(args))
+        return jsonify(row_column_dump_schema.dump(csv_file))
     except Exception:
         db.session.rollback()
         raise

--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -268,10 +268,12 @@ def batch_modify_label(csv_id):
                 csv_file.group_column_index = index
             setattr(column, 'column_type', label)
             db.session.add(column)
+
     db.session.add(csv_file)
+
     try:
         db.session.commit()
-        return jsonify(csv_file_schema.dump(csv_file))
+        return jsonify(modify_label_list_schema.dump(args))
     except Exception:
         db.session.rollback()
         raise

--- a/tests/test_row_column.py
+++ b/tests/test_row_column.py
@@ -102,8 +102,13 @@ def test_modify_column(client, table):
         json={'changes': [{'context': 'column', 'index': 1, 'label': 'metadata'}]}
     )
     assert resp.status_code == 200
+
     # Right now columns[1] is column_index=1, but it would be nice
     # to know if that breaks.
+    resp = client.get(
+        url_for('csv.get_csv_file', csv_id=table.id)
+    )
+    assert resp.status_code == 200
     assert resp.json['columns'][1]['column_type'] == 'metadata'
 
 
@@ -111,6 +116,11 @@ def test_modify_row(client, table):
     resp = client.put(
         url_for('csv.batch_modify_label', csv_id=table.id),
         json={'changes': [{'context': 'row', 'index': 1, 'label': 'masked'}]}
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(
+        url_for('csv.get_csv_file', csv_id=table.id)
     )
     assert resp.status_code == 200
     assert resp.json['rows'][1]['row_type'] == 'masked'
@@ -125,6 +135,11 @@ def test_batch_modify_in_order(client, table):
                 {'context': 'row', 'index': 1, 'label': 'sample'},
             ]
         }
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(
+        url_for('csv.get_csv_file', csv_id=table.id)
     )
     assert resp.status_code == 200
     assert resp.json['rows'][1]['row_type'] == 'sample'
@@ -142,7 +157,12 @@ def test_batch_modify_invalid_state(client, table):
         }
     )
     assert resp.status_code == 200
-    assert len(resp.json['table_validation']) > 0
+
+    resp = client.get(
+        url_for('csv.get_csv_file_validation', csv_id=table.id)
+    )
+    assert resp.status_code == 200
+    assert len(resp.json) > 0
 
 
 def test_batch_modify_row_and_column(client, table):
@@ -154,6 +174,11 @@ def test_batch_modify_row_and_column(client, table):
                 {'context': 'column', 'index': 2, 'label': 'masked'},
             ]
         }
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(
+        url_for('csv.get_csv_file', csv_id=table.id)
     )
     assert resp.status_code == 200
     assert resp.json['rows'][1]['row_type'] == 'masked'

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -76,7 +76,7 @@ function _invalidatePlots(state, { key, plotList }) {
   });
 }
 function _setLables(state, { key, rows, columns }) {
-  _invalidatePlots(state, { key, plotList: ['pca', 'loadings'] })
+  _invalidatePlots(state, { key, plotList: ['pca', 'loadings'] });
   const rowsSorted = rows.sort((a, b) => a.row_index - b.row_index);
   const colsSorted = columns.sort((a, b) => a.column_index - b.column_index);
   Vue.set(state.datasets[key], 'row', {
@@ -103,10 +103,11 @@ export async function load_dataset({ commit }, { dataset_id, selected }) {
 const mutations = {
 
   [SET_SOURCE_DATA](state, { data }) {
+    const { id, name, size } = data;
     if (!state.plots[id]) {
       Vue.set(state.plots, id, cloneDeep(plotDefaults));
     }
-    const { id, name, size } = data;
+    const cols = data.columns.sort((a, b) => a.column_index - b.column_index);
     // serialize CSV string as JSON
     const { data: sourcerows } = convertCsvToRows(data.table);
     Vue.set(state.datasets, id, {

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -22,6 +22,7 @@ import {
   SET_DATASET,
   SET_LAST_ERROR,
   SET_LOADING,
+  SET_LABELS,
   SET_SELECTION,
   SET_SESSION_STORE,
   SET_SOURCE_DATA,
@@ -74,14 +75,25 @@ function _invalidatePlots(state, { key, plotList }) {
     Vue.set(state.plots[key][name], 'valid', false);
   });
 }
+function _setLables(state, { key, rows, columns }) {
+  _invalidatePlots(state, { key, plotList: ['pca', 'loadings'] })
+  const rowsSorted = rows.sort((a, b) => a.row_index - b.row_index);
+  const colsSorted = columns.sort((a, b) => a.column_index - b.column_index);
+  Vue.set(state.datasets[key], 'row', {
+    labels: rowsSorted.map(r => r.row_type),
+  });
+  Vue.set(state.datasets[key], 'column', {
+    labels: colsSorted.map(c => c.column_type),
+  });
+}
 
 /*
  * Private action helpers
  */
-export async function load_dataset({ commit }, { dataset_id }) {
+export async function load_dataset({ commit }, { dataset_id, selected }) {
   try {
     const { data } = await CSVService.get(dataset_id);
-    commit(SET_SOURCE_DATA, { data });
+    commit(SET_SOURCE_DATA, { data: { ...data, selected } });
   } catch (err) {
     commit(SET_LAST_ERROR, err);
     throw err;
@@ -91,13 +103,12 @@ export async function load_dataset({ commit }, { dataset_id }) {
 const mutations = {
 
   [SET_SOURCE_DATA](state, { data }) {
+    if (!state.plots[id]) {
+      Vue.set(state.plots, id, cloneDeep(plotDefaults));
+    }
     const { id, name, size } = data;
-    // Server doesn't guarantee order of indices.
-    const rows = data.rows.sort((a, b) => a.row_index - b.row_index);
-    const cols = data.columns.sort((a, b) => a.column_index - b.column_index);
     // serialize CSV string as JSON
     const { data: sourcerows } = convertCsvToRows(data.table);
-
     Vue.set(state.datasets, id, {
       // API response from server
       _source: data,
@@ -108,12 +119,6 @@ const mutations = {
       width: sourcerows[0].length, // TODO: get from server
       height: sourcerows.length, // TODO: get from server
       // user- and server-generated lables for rows and columns
-      row: {
-        labels: rows.map(r => r.row_type),
-      },
-      column: {
-        labels: cols.map(c => c.column_type),
-      },
       validation: mapValidationErrors(data.table_validation, cols),
       selected: data.selected || {
         type: 'column',
@@ -131,9 +136,15 @@ const mutations = {
       imputationMNAR: data.imputation_mnar,
       scaling: data.scaling,
     });
-    if (!state.plots[id]) {
-      Vue.set(state.plots, id, cloneDeep(plotDefaults));
-    }
+    _setLables(state, {
+      key: id,
+      rows: data.rows,
+      columns: data.columns,
+    });
+  },
+
+  [SET_LABELS](state, { key, rows, columns }) {
+    _setLables(state, { key, rows, columns });
   },
 
   [SET_DATASET](state, { dataset }) {
@@ -262,8 +273,10 @@ const actions = {
     commit(SET_LOADING, true);
     try {
       const { data } = await CSVService.updateLabel(dataset_id, changes);
+      const { rows, columns } = data;
+      commit(SET_LABELS, { key: dataset_id, rows, columns });
       const { selected } = state.datasets[dataset_id];
-      commit(SET_SOURCE_DATA, { data: { ...data, selected } });
+      load_dataset({ commit }, { dataset_id, selected });
     } catch (err) {
       commit(SET_LAST_ERROR, err);
       commit(SET_LOADING, false);

--- a/web/src/store/mutations.type.js
+++ b/web/src/store/mutations.type.js
@@ -1,6 +1,7 @@
 export const REFRESH_PLOT = 'refresh_plot';
 export const REMOVE_DATASET = 'remove_dataset';
 export const SET_DATASET = 'set_dataset';
+export const SET_LABELS = 'set_labels';
 export const SET_LAST_ERROR = 'set_last_error';
 export const SET_LOADING = 'set_loading';
 export const SET_SELECTION = 'set_selection';


### PR DESCRIPTION
This addressed #157.  The client needs to be updated to handle the api change on `PUT /csv/:id/batch/label`.