### PR TITLE
Add a "validated_metabolite_table"

### DIFF
--- a/devops/ansible/site.yml
+++ b/devops/ansible/site.yml
@@ -168,5 +168,6 @@
         FLASK_APP: "metabulo.wsgi"
         SQLALCHEMY_DATABASE_URI: sqlite:///{{ sqlalchemy_database_path }}
         DOTENV_PATH: "/home/gunicorn"
+        OPENCPU_API_ROOT: "{{ opencpu_api_root }}"
       become: true
       become_user: gunicorn

--- a/metabulo/models.py
+++ b/metabulo/models.py
@@ -23,7 +23,7 @@ from metabulo.imputation import IMPUTE_MCAR_METHODS, impute_missing, IMPUTE_MNAR
 from metabulo.normalization import NORMALIZATION_METHODS, normalize
 from metabulo.scaling import scale, SCALING_METHODS
 from metabulo.table_validation import get_fatal_index_errors, get_validation_list
-from metabulo.transformation import transform
+from metabulo.transformation import transform, TRANSFORMATION_METHODS
 
 
 # This is to avoid having to manually name all constraints
@@ -731,6 +731,7 @@ class ValidatedMetaboliteTableSchema(BaseSchema):
     normalization = fields.Str(missing=None, validate=validate.OneOf(NORMALIZATION_METHODS))
     normalization_argument = fields.Str(missing=None)
     scaling = fields.Str(missing=None, validate=validate.OneOf(SCALING_METHODS))
+    transformation = fields.Str(missing=None, validate=validate.OneOf(TRANSFORMATION_METHODS))
     meta = fields.Dict(missing=dict)
 
     # not included in the serialized output

--- a/metabulo/views.py
+++ b/metabulo/views.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from io import BytesIO
 import json
 import math
@@ -14,12 +15,12 @@ from metabulo.models import AXIS_NAME_TYPES, CSVFile, CSVFileSchema, db, \
     ModifyLabelListSchema, \
     TABLE_COLUMN_TYPES, TABLE_ROW_TYPES, \
     TableColumn, TableColumnSchema, TableRow, \
-    TableRowSchema
+    TableRowSchema, ValidatedMetaboliteTable, ValidatedMetaboliteTableSchema
 from metabulo.normalization import validate_normalization_method
 from metabulo.opencpu import OpenCPUException
 from metabulo.plot import pca
 from metabulo.scaling import SCALING_METHODS
-from metabulo.table_validation import get_fatal_index_errors, ValidationSchema
+from metabulo.table_validation import ValidationSchema
 from metabulo.transformation import TRANSFORMATION_METHODS
 
 csv_file_schema = CSVFileSchema()
@@ -27,8 +28,21 @@ modify_label_list_schema = ModifyLabelListSchema()
 table_column_schema = TableColumnSchema(exclude=['csv_file'])
 table_row_schema = TableRowSchema(exclude=['csv_file'])
 validation_schema = ValidationSchema()
+validated_metabolite_table_schema = ValidatedMetaboliteTableSchema()
 
 csv_bp = Blueprint('csv', __name__)
+
+
+def load_validated_csv_file(func):
+
+    @wraps(func)
+    def wrapped(csv_id, *arg, **kwargs):
+        csv_file = ValidatedMetaboliteTable.query \
+            .filter_by(csv_file_id=csv_id) \
+            .first_or_404()
+        return func(csv_file, *arg, **kwargs)
+
+    return wrapped
 
 
 @csv_file_cache
@@ -174,62 +188,6 @@ def set_imputation_options(csv_id, **kwargs):
         raise
 
 
-# Ingest transforms
-@csv_bp.route('/csv/<uuid:csv_id>/normalization', methods=['PUT'])
-@use_kwargs({
-    'method': fields.Str(allow_none=True),
-    'argument': fields.Str(allow_none=True)
-}, validate=validate_normalization_method)
-def set_normalization_method(csv_id, **kwargs):
-    csv_file = CSVFile.query.get_or_404(csv_id)
-    method = kwargs['method']
-    argument = kwargs.get('argument', None)
-
-    try:
-        csv_file.normalization = method
-        csv_file.normalization_argument = argument
-        db.session.add(csv_file)
-        db.session.commit()
-        return jsonify(method)
-    except Exception:
-        db.session.rollback()
-        raise
-
-
-@csv_bp.route('/csv/<uuid:csv_id>/transformation', methods=['PUT'])
-def set_transformation_method(csv_id):
-    csv_file = CSVFile.query.get_or_404(csv_id)
-    args = request.json
-    method = args['method']
-    if method is not None and method not in TRANSFORMATION_METHODS:
-        raise ValidationError('Invalid transformation method', data=method)
-    try:
-        csv_file.transformation = method
-        db.session.add(csv_file)
-        db.session.commit()
-        return jsonify(method)
-    except Exception:
-        db.session.rollback()
-        raise
-
-
-@csv_bp.route('/csv/<uuid:csv_id>/scaling', methods=['PUT'])
-def set_scaling_method(csv_id):
-    csv_file = CSVFile.query.get_or_404(csv_id)
-    args = request.json
-    method = args['method']
-    if method is not None and method not in SCALING_METHODS:
-        raise ValidationError('Invalid scaling method', data=method)
-    try:
-        csv_file.scaling = method
-        db.session.add(csv_file)
-        db.session.commit()
-        return jsonify(method)
-    except Exception:
-        db.session.rollback()
-        raise
-
-
 # Row/Column API
 @csv_bp.route('/csv/<uuid:csv_id>/column', methods=['GET'])
 def list_columns(csv_id):
@@ -309,9 +267,9 @@ class ServerError(Exception):
         return jsonify(self.response), self.code
 
 
-def _apply_transforms(csv_file):
+def serialize_validated_table(validated_table):
     try:
-        table = csv_file.apply_transforms()
+        return validated_metabolite_table_schema.dump(validated_table)
     except OpenCPUException as e:
         response = 'Connection failed' if e.response is None else e.response.content.decode()
         code = 504 if e.response is None else 502
@@ -321,47 +279,94 @@ def _apply_transforms(csv_file):
             'method': e.method,
             'response': response
         }, code)
+    except Exception as e:
+        current_app.logger.exception(e)
+        raise ValidationError('Error applying data transformation')
 
-    return table
+
+# Endpoints below here act on "ValidatedMetaboliteTable" rather "CSVFile"
+@csv_bp.route('/csv/<uuid:csv_id>/normalization', methods=['PUT'])
+@use_kwargs({
+    'method': fields.Str(allow_none=True),
+    'argument': fields.Str(allow_none=True)
+}, validate=validate_normalization_method)
+@load_validated_csv_file
+def set_normalization_method(validated_table, **kwargs):
+    method = kwargs['method']
+    argument = kwargs.get('argument', None)
+
+    try:
+        validated_table.normalization = method
+        validated_table.normalization_argument = argument
+        serialized = serialize_validated_table(validated_table)
+        db.session.add(validated_table)
+        db.session.commit()
+        return jsonify(serialized)
+    except Exception:
+        db.session.rollback()
+        raise
 
 
-def _get_pca_data(csv_file):
-    table = _apply_transforms(csv_file)
+@csv_bp.route('/csv/<uuid:csv_id>/transformation', methods=['PUT'])
+@load_validated_csv_file
+def set_transformation_method(validated_table):
+    args = request.json
+    method = args['method']
+    if method is not None and method not in TRANSFORMATION_METHODS:
+        raise ValidationError('Invalid transformation method', data=method)
+    try:
+        validated_table.transformation = method
+        serialized = serialize_validated_table(validated_table)
+        db.session.add(validated_table)
+        db.session.commit()
+        return jsonify(serialized)
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+@csv_bp.route('/csv/<uuid:csv_id>/scaling', methods=['PUT'])
+@load_validated_csv_file
+def set_scaling_method(validated_table):
+    args = request.json
+    method = args['method']
+    if method is not None and method not in SCALING_METHODS:
+        raise ValidationError('Invalid scaling method', data=method)
+    try:
+        validated_table.scaling = method
+        serialized = serialize_validated_table(validated_table)
+        db.session.add(validated_table)
+        db.session.commit()
+        return jsonify(serialized)
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+def _get_pca_data(validated_table):
+    table = validated_table.measurements
     max_components = int(request.args.get('max_components', 2))
     data = pca(table, max_components)
 
     # insert per row label metadata information
-    labels = csv_file.sample_metadata
-    groups = csv_file.groups
+    labels = validated_table.sample_metadata
+    groups = validated_table.groups
     data['labels'] = pandas.concat([groups, labels], axis=1).to_dict('list')
     data['rows'] = table.index.tolist()
 
     return data
 
 
-def _get_csv_file(csv_id):
-    csv_file = CSVFile.query.get_or_404(csv_id)
-
-    fatal_errors = get_fatal_index_errors(csv_file)
-    if fatal_errors:
-        raise ServerError({
-            'error': 'Fatal error in table validation',
-            'validation': validation_schema.dump(fatal_errors, many=True)
-        }, 400)
-
-    return csv_file
-
-
 @csv_bp.route('/csv/<uuid:csv_id>/plot/pca', methods=['GET'])
-def get_pca_plot(csv_id):
+@load_validated_csv_file
+def get_pca_plot(validated_table):
     try:
-        csv_file = _get_csv_file(csv_id)
-        return jsonify(_get_pca_data(csv_file)), 200
+        return jsonify(_get_pca_data(validated_table)), 200
     except ServerError as e:
         return e.return_value()
 
 
-def _get_loadings_data(csv_file):
+def _get_loadings_data(validated_table):
     def mean(x):
         return sum(x) / len(x)
 
@@ -384,8 +389,8 @@ def _get_loadings_data(csv_file):
         prod_sum = sum(map(lambda x, y: (x - x_mean) * (y - y_mean), xs, ys))
         return prod_sum / (x_stddev * y_stddev)
 
-    table = _apply_transforms(csv_file)
-    pca_data = _get_pca_data(csv_file)
+    table = validated_table.measurements
+    pca_data = _get_pca_data(validated_table)
 
     # Transpose the PCA values.
     pca_data = [list(x) for x in zip(*pca_data['x'])]
@@ -397,16 +402,17 @@ def _get_loadings_data(csv_file):
 
 
 @csv_bp.route('/csv/<uuid:csv_id>/plot/loadings', methods=['GET'])
-def get_loadings_plot(csv_id):
+@load_validated_csv_file
+def get_loadings_plot(validated_table):
     try:
-        csv_file = _get_csv_file(csv_id)
-        return jsonify(_get_loadings_data(csv_file)), 200
+        return jsonify(_get_loadings_data(validated_table)), 200
     except ServerError as e:
         return e.return_value()
 
 
 @csv_bp.route('/csv/<uuid:csv_id>/pca-overview', methods=['GET'])
-def get_pca_overview(csv_id):
-    csv_file = CSVFile.query.get_or_404(csv_id)
-    png_content = opencpu.generate_image('/metabulo/R/pca_overview_plot', csv_file.table)
+@load_validated_csv_file
+def get_pca_overview(validated_table):
+    png_content = opencpu.generate_image('/metabulo/R/pca_overview_plot',
+                                         validated_table.measurements)
     return Response(png_content, mimetype='image/png')

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -42,7 +42,7 @@ def run_migrations_offline():
 
     """
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url)
+    context.configure(url=url, render_as_batch=True)
 
     with context.begin_transaction():
         context.run_migrations()

--- a/migrations/versions/543488f52e75_refactor_csv_file_model.py
+++ b/migrations/versions/543488f52e75_refactor_csv_file_model.py
@@ -1,0 +1,84 @@
+"""
+refactor csv file model
+
+Revision ID: 543488f52e75
+Revises: 44b9d38a1bb9
+Create Date: 2019-09-05 10:08:04.700364
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+from metabulo.models import CSVFile, db, ValidatedMetaboliteTable
+
+
+revision = '543488f52e75'
+down_revision = '44b9d38a1bb9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'validated_metabolite_table',
+        sa.Column('id', sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column('created', sa.DateTime(), nullable=False),
+        sa.Column('csv_file_id', sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('normalization', sa.String(), nullable=True),
+        sa.Column('normalization_argument', sa.String(), nullable=True),
+        sa.Column('transformation', sa.String(), nullable=True),
+        sa.Column('scaling', sa.String(), nullable=True),
+        sa.Column('meta', sqlalchemy_utils.types.json.JSONType(), nullable=False),
+        sa.Column('raw_measurements_bytes', sa.LargeBinary(), nullable=False),
+        sa.Column('measurement_metadata_bytes', sa.LargeBinary(), nullable=False),
+        sa.Column('sample_metadata_bytes', sa.LargeBinary(), nullable=False),
+        sa.Column('groups_bytes', sa.LargeBinary(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['csv_file_id'], ['csv_file.id'],
+            name=op.f('fk_validated_metabolite_table_csv_file_id_csv_file')),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_validated_metabolite_table'))
+    )
+    op.create_index(
+        op.f('ix_validated_metabolite_table_csv_file_id'),
+        'validated_metabolite_table', ['csv_file_id'], unique=True)
+
+    for csv_file in CSVFile.query:
+        try:
+            validated_table = ValidatedMetaboliteTable.create_from_csv_file(csv_file)
+        except Exception:
+            continue
+
+        db.session.add(validated_table)
+    db.session.commit()
+
+    # sqlite doesn't support this operation:
+    # op.drop_column('csv_file', 'scaling')
+    # op.drop_column('csv_file', 'normalization_argument')
+    # op.drop_column('csv_file', 'transformation')
+    # op.drop_column('csv_file', 'normalization')
+
+    op.execute('ALTER TABLE csv_file RENAME TO csv_file_old;')
+    op.execute("""
+        CREATE TABLE csv_file AS
+            SELECT
+                id,
+                created,
+                name,
+                imputation_mnar,
+                imputation_mcar,
+                meta
+            FROM csv_file_old;
+    """)
+    op.execute('DROP TABLE csv_file_old;')
+
+
+def downgrade():
+    op.add_column('csv_file', sa.Column('normalization', sa.VARCHAR(), nullable=True))
+    op.add_column('csv_file', sa.Column('transformation', sa.VARCHAR(), nullable=True))
+    op.add_column('csv_file', sa.Column('normalization_argument', sa.VARCHAR(), nullable=True))
+    op.add_column('csv_file', sa.Column('scaling', sa.VARCHAR(), nullable=True))
+    op.drop_index(
+        op.f('ix_validated_metabolite_table_csv_file_id'), table_name='validated_metabolite_table')
+    op.drop_table('validated_metabolite_table')

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -9,7 +9,7 @@ import pytest
 from metabulo import normalization
 from metabulo import scaling
 from metabulo import transformation
-from metabulo.models import CSVFile
+from metabulo.models import CSVFile, db, ValidatedMetaboliteTable
 
 
 @pytest.fixture
@@ -20,6 +20,14 @@ id,col1,col2
 row1,0.5,2.0
 row2,1.5,0.0
 """), index_col=0)
+
+
+@pytest.fixture
+def validated_table(app, csv_file):
+    validated_table = ValidatedMetaboliteTable.create_from_csv_file(csv_file)
+    db.session.add(validated_table)
+    db.session.commit()
+    yield validated_table
 
 
 @pytest.fixture
@@ -67,20 +75,22 @@ def test_normalize_weight_volume(table, column_meta):
     assert_frame_equal(t, correct)
 
 
-def test_normalize_api(client, csv_file):
+def test_normalize_api(client, csv_file, validated_table):
     resp = client.put(
         url_for('csv.set_normalization_method', csv_id=csv_file.id), json={'method': 'minmax'}
     )
     assert resp.status_code == 200
-    assert resp.json == 'minmax'
-    assert abs(CSVFile.query.get(csv_file.id).measurement_table.iloc[0, 0]) < 1e-8
+    assert resp.json['normalization'] == 'minmax'
+    assert abs(ValidatedMetaboliteTable.query.get(validated_table.id)
+               .measurements.iloc[0, 0]) < 1e-8
 
     resp = client.put(
         url_for('csv.set_normalization_method', csv_id=csv_file.id), json={'method': None}
     )
     assert resp.status_code == 200
-    assert resp.json is None
-    assert CSVFile.query.get(csv_file.id).measurement_table.iloc[0, 0] == 0.5
+    assert resp.json['normalization'] is None
+    assert ValidatedMetaboliteTable.query.get(validated_table.id) \
+        .measurements.iloc[0, 0] == 0.5
 
 
 def test_scale_none(table):
@@ -94,20 +104,22 @@ def test_scale_auto(table):
     assert abs(t.iloc[0, 0] + math.sqrt(0.5)) < 1e-8
 
 
-def test_scale_api(client, csv_file):
+def test_scale_api(client, csv_file, validated_table):
     resp = client.put(
         url_for('csv.set_scaling_method', csv_id=csv_file.id), json={'method': 'auto'}
     )
     assert resp.status_code == 200
-    assert resp.json == 'auto'
-    assert abs(CSVFile.query.get(csv_file.id).measurement_table.iloc[0, 0] + math.sqrt(0.5)) < 1e-8
+    assert resp.json['scaling'] == 'auto'
+    assert abs(ValidatedMetaboliteTable.query.get(validated_table.id)
+               .measurements.iloc[0, 0] + math.sqrt(0.5)) < 1e-8
 
     resp = client.put(
         url_for('csv.set_scaling_method', csv_id=csv_file.id), json={'method': None}
     )
     assert resp.status_code == 200
-    assert resp.json is None
-    assert CSVFile.query.get(csv_file.id).measurement_table.iloc[0, 0] == 0.5
+    assert resp.json['scaling'] is None
+    assert ValidatedMetaboliteTable.query.get(validated_table.id) \
+        .measurements.iloc[0, 0] == 0.5
 
 
 def test_transform_none(table):
@@ -121,18 +133,21 @@ def test_transform_log10(table):
     assert abs(t.iloc[0, 0] - math.log10(0.5)) < 1e-8
 
 
-def test_transform_api(client, csv_file):
+def test_transform_api(client, csv_file, validated_table):
     csv_file = CSVFile.query.get(csv_file.id)
     resp = client.put(
         url_for('csv.set_transformation_method', csv_id=csv_file.id), json={'method': 'squareroot'}
     )
     assert resp.status_code == 200
-    assert resp.json == 'squareroot'
-    assert CSVFile.query.get(csv_file.id).measurement_table.iloc[0, 0] == math.sqrt(0.5)
+    print(resp.json.keys())
+    assert resp.json['transformation'] == 'squareroot'
+    assert ValidatedMetaboliteTable.query.get(validated_table.id) \
+        .measurements.iloc[0, 0] == math.sqrt(0.5)
 
     resp = client.put(
         url_for('csv.set_transformation_method', csv_id=csv_file.id), json={'method': None}
     )
     assert resp.status_code == 200
-    assert resp.json is None
-    assert CSVFile.query.get(csv_file.id).measurement_table.iloc[0, 0] == 0.5
+    assert resp.json['transformation'] is None
+    assert ValidatedMetaboliteTable.query.get(validated_table.id) \
+        .measurements.iloc[0, 0] == 0.5

--- a/web/src/common/api.service.js
+++ b/web/src/common/api.service.js
@@ -76,4 +76,8 @@ export const CSVService = {
   updateLabel(csvSlug, changes) {
     return ApiService.put(`csv/${csvSlug}/batch/label`, { changes });
   },
+
+  validateTable(slug) {
+    return ApiService.post(`csv/${slug}/validate`);
+  },
 };

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -96,6 +96,7 @@ export async function load_dataset({ commit }, { dataset_id, selected }) {
   try {
     const { data } = await CSVService.get(dataset_id);
     commit(SET_SOURCE_DATA, { data: { ...data, selected } });
+    await CSVService.validateTable(dataset_id);
   } catch (err) {
     commit(SET_LAST_ERROR, err);
     throw err;


### PR DESCRIPTION
This implements the refactor we have discussed.  It essentially checkpoints the old `CSVFile` model post imputation.  The purpose of the new table is to store metabolite tables that are *guaranteed* to be valid, so that rather than perform validation lazily in GET requests, they can be done in the PUT request that performs the mutation.

The API changes here are intentionally minimal.  There really is only one minor change that needs to happen in the client.  That is a call to `POST /api/v1/csv/:id/validate` when the clean up is done (or really any time the client wishes to check if the csv_file state is valid).  On success, this will upsert a row in the new table with the given csv file id.  The functionality of the new endpoint could be placed in `GET /api/v1/csv/:id`, but hiding database mutations in a GET requests feels icky.

A caveat: I made no attempt to invalidate this table automatically if something changes on the source csv_file row.  It would be possible (and not that hard), but I don't think it is necessary currently.

You can try it now by uploading a new csv file and performing the cleanup as before.  Once this is done, manually call the  `POST /api/v1/csv/:id/validate` endpoint.  The visualization page should then work correctly.

I haven't bothered updating the tests or generating a migration, but I will do so once others get a chance to comment on it.