### PR TITLE
fix scrollbars just around table

### DIFF
--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -148,13 +148,19 @@ v-layout.cleanup-wrapper(row)
             v-btn(flat, @click="saveImputationSettings") Save
       v-icon {{ $vuetify.icons.download }}
 
-    .overflow-auto
+    .grow-overflow
       data-table(v-bind="{ id, dataset, selected }", @setselection="setSelection")
 </template>
 
 <style lang="scss">
 .cleanup-wrapper {
   width: 100%;
+
+  .grow-overflow {
+    flex: 1 1 0;
+    overflow: auto;
+    max-height: 100%;
+  }
 
   .radio-toolbar {
     .v-toolbar__content {


### PR DESCRIPTION
in the current version a large cleanup table scrolls the whole page. This will limit it to the table. 