### PR TITLE
fix loadings plot tooltip

### DIFF
--- a/web/src/components/vis/LoadingsPlot.vue
+++ b/web/src/components/vis/LoadingsPlot.vue
@@ -185,7 +185,7 @@ export default {
             tooltip.transition()
               .duration(duration)
               .style('opacity', 0.9);
-            tooltip.html(`<b>${d.col}</b><br>(${coordFormat(d.x)}, ${coordFormat(d.y)})`)
+            tooltip.html(`<b>${d.col}</b><br>(${coordFormat(d.cor[pcX - 1])}, ${coordFormat(d.cor[pcY - 1])})`)
               .style('left', `${event.clientX + 15}px`)
               .style('top', `${event.pageY - 30}px`);
           })


### PR DESCRIPTION
it just showed `(NaN, NaN)`

![Screenshot from 2019-09-11 16-49-40](https://user-images.githubusercontent.com/4129778/64734415-988ba080-d4b4-11e9-83e4-ec16c4a3b600.png)
