### PR TITLE
extend layout fixes

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -40,7 +40,8 @@ body {
     }
   }
 
-  .overflow-auto {
+  .grow-overflow {
+    flex: 1 1 0;
     overflow: auto;
     max-height: 100%;
   }

--- a/web/src/components/Cleanup.vue
+++ b/web/src/components/Cleanup.vue
@@ -156,12 +156,6 @@ v-layout.cleanup-wrapper(row)
 .cleanup-wrapper {
   width: 100%;
 
-  .grow-overflow {
-    flex: 1 1 0;
-    overflow: auto;
-    max-height: 100%;
-  }
-
   .radio-toolbar {
     .v-toolbar__content {
       height: inherit !important;

--- a/web/src/components/Transform.vue
+++ b/web/src/components/Transform.vue
@@ -149,18 +149,19 @@ v-layout.transform-component(row, fill-height)
   v-layout(v-if="!dataset || !ready", justify-center, align-center)
     v-progress-circular(indeterminate, size="100", width="5")
     h4.display-1.pa-3 Loading Data Set
-  v-container.overflow-auto.ma-0(grid-list-lg, fluid, v-else-if="ready && valid")
-    v-layout(row, wrap)
-      score-plot-tile(
-          :width="600",
-          :height="600",
-          :raw-points="pcaData",
-          :dataset="dataset")
-      loadings-plot-tile(
-          :width="600",
-          :height="600",
-          :points="loadingsData")
-  v-container.overflow-auto(v-else-if="ready", fill-height)
+  v-layout(column, v-else-if="ready && valid")
+    v-container.grow-overflow.ma-0(grid-list-lg, fluid)
+      v-layout(row, wrap)
+        score-plot-tile(
+            :width="600",
+            :height="600",
+            :raw-points="pcaData",
+            :dataset="dataset")
+        loadings-plot-tile(
+            :width="600",
+            :height="600",
+            :points="loadingsData")
+  v-container(v-else-if="ready", fill-height)
     v-layout(column)
       .display-2 Error: Cannot show transform table
       a.headline(:href="`#/pretreatment/${dataset.id}/cleanup`") Correct validation error(s)

--- a/web/src/components/Upload.vue
+++ b/web/src/components/Upload.vue
@@ -121,7 +121,7 @@ v-layout.upload-component(column, fill-height)
         v-btn(@click="doDelete = () => {}; deleteCount = 0;", flat) Cancel
         v-btn(@click="doDelete(); deleteCount = 0", color="error") Delete
 
-  v-layout.overflow-auto(column, fill-height)
+  v-layout.grow-overflow(column, fill-height)
     .ma-4
       h3.headline.font-weight-bold.primary--text.text--darken-3 Upload your data (csv or txt)
       p.secondary--text.text--lighten-1 Choose a file from your computer


### PR DESCRIPTION
I've been trying to achieve this with vuetify for a long time, but with no way to set flex-basis, I couldn't get what I wanted.

This change moves your grow-overflow style to app.vue which is where overflow-auto came from, and that's the behavior I wanted from that all along.   It also makes the transform and upload layouts work the same way.

