### PR TITLE
Refactor plot recomputation into mixin

### DIFF
--- a/web/src/components/Transform.vue
+++ b/web/src/components/Transform.vue
@@ -1,6 +1,6 @@
 <script>
 import { mapState } from 'vuex';
-import { MUTEX_TRANSFORM_TABLE, LOAD_PLOT } from '@/store/actions.type';
+import { MUTEX_TRANSFORM_TABLE } from '@/store/actions.type';
 import {
   normalize_methods,
   scaling_methods,
@@ -39,46 +39,8 @@ export default {
     norm_arg() { return this.$store.getters.txType(this.id, 'normalization_argument'); },
     trans() { return this.$store.getters.txType(this.id, 'transformation'); },
     scaling() { return this.$store.getters.txType(this.id, 'scaling'); },
-    pcaData() { return this.$store.getters.plotData(this.id, 'pca'); },
-    pcaValid() { return this.$store.getters.plotValid(this.id, 'pca'); },
-    loadingsData() { return this.$store.getters.plotData(this.id, 'loadings'); },
-    loadingsValid() { return this.$store.getters.plotValid(this.id, 'loadings'); },
-  },
-  watch: {
-    pcaValid: {
-      immediate: true,
-      handler(valid) { this.pcaLoader(valid); },
-    },
-    loadingsValid: {
-      immediate: true,
-      handler(valid) { this.loadingsLoader(valid); },
-    },
-    id() {
-      this.pcaLoader(this.pcaValid);
-      this.loadingsLoader(this.loadingsValid);
-    },
-    loading() {
-      this.pcaLoader(this.pcaValid);
-      this.loadingsLoader(this.loadingsValid);
-    },
   },
   methods: {
-    pcaLoader(valid) {
-      if (valid === false) {
-        this.$store.dispatch(LOAD_PLOT, {
-          dataset_id: this.id,
-          name: 'pca',
-        });
-      }
-    },
-    loadingsLoader(valid) {
-      if (valid === false) {
-        this.$store.dispatch(LOAD_PLOT, {
-          dataset_id: this.id,
-          name: 'loadings',
-        });
-      }
-    },
     async transformTable(value, category, argument, methods) {
       /* If there's no argument and there should be, pick the firt from the list */
       const method = methods.find(v => v.value === value);
@@ -157,16 +119,15 @@ v-layout.transform-component(row, fill-height)
         score-plot-tile(
             :width="600",
             :height="600",
-            :raw-points="pcaData",
-            :dataset="dataset")
+            :id="id")
         loadings-plot-tile(
             :width="600",
             :height="600",
-            :points="loadingsData")
+            :id="id")
         scree-plot-tile(
             :width="600",
             :height="600",
-            :eigenvalues="pcaData.sdev")
+            :id="id")
   v-container(v-else-if="ready", fill-height)
     v-layout(column)
       .display-2 Error: Cannot show transform table

--- a/web/src/components/vis/LoadingsPlotTile.vue
+++ b/web/src/components/vis/LoadingsPlotTile.vue
@@ -1,12 +1,15 @@
 <script>
-import LoadingsPlot from '@/components/vis/LoadingsPlot.vue';
-import VisTile from '@/components/vis/VisTile.vue';
+import LoadingsPlot from './LoadingsPlot.vue';
+import VisTile from './VisTile.vue';
+import { plotDataMixin } from '../../utils/mixins';
 
 export default {
   components: {
     LoadingsPlot,
     VisTile,
   },
+
+  mixins: [plotDataMixin('loadings')],
 
   props: {
     width: {
@@ -19,8 +22,8 @@ export default {
       type: Number,
       validator: Number.isInteger,
     },
-    points: {
-      validator: d => d === null || Array.isArray(d),
+    id: {
+      type: String,
       required: true,
     },
   },
@@ -47,11 +50,11 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile(title="PCA Loadings Plot")
+vis-tile(title="PCA Loadings Plot", :loading="plot.loading")
   loadings-plot(
       :width="width",
       :height="height",
-      :points="points",
+      :points="plot.data",
       :pc-x="pcX",
       :pc-y="pcY",
       :show-crosshairs="showCrosshairs")

--- a/web/src/components/vis/ScorePlotTile.vue
+++ b/web/src/components/vis/ScorePlotTile.vue
@@ -1,12 +1,15 @@
 <script>
 import ScorePlot from '@/components/vis/ScorePlot.vue';
 import VisTile from '@/components/vis/VisTile.vue';
+import { plotDataMixin } from '../../utils/mixins';
 
 export default {
   components: {
     ScorePlot,
     VisTile,
   },
+
+  mixins: [plotDataMixin('pca')],
 
   props: {
     width: {
@@ -19,13 +22,9 @@ export default {
       type: Number,
       validator: Number.isInteger,
     },
-    rawPoints: {
+    id: {
+      type: String,
       required: true,
-      validator: d => d === null || d instanceof Object,
-    },
-    dataset: {
-      required: true,
-      type: Object,
     },
   },
 
@@ -51,11 +50,11 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile(title="PCA Score Plot")
+vis-tile(title="PCA Score Plot", :loading="plot.loading")
   score-plot(
       :width="width",
       :height="height",
-      :raw-points="rawPoints",
+      :raw-points="plot.data",
       :dataset="dataset",
       :pc-x="pcX",
       :pc-y="pcY",

--- a/web/src/components/vis/ScreePlotTile.vue
+++ b/web/src/components/vis/ScreePlotTile.vue
@@ -42,11 +42,11 @@ export default {
 </script>
 
 <template lang="pug">
-vis-tile(title="PCA Scree Plot")
+vis-tile(title="PCA Scree Plot", :loading="plot.loading")
   scree-plot(
       :width="width",
       :height="height",
-      :eigenvalues="plot.data.s",
+      :eigenvalues="plot.data.sdev",
       :num-components="numComponents",
       :show-cutoffs="showCutoffs")
   template(v-slot:controls)

--- a/web/src/components/vis/ScreePlotTile.vue
+++ b/web/src/components/vis/ScreePlotTile.vue
@@ -1,12 +1,15 @@
 <script>
 import ScreePlot from '@/components/vis/ScreePlot.vue';
 import VisTile from '@/components/vis/VisTile.vue';
+import { plotDataMixin } from '../../utils/mixins';
 
 export default {
   components: {
     ScreePlot,
     VisTile,
   },
+
+  mixins: [plotDataMixin('pca')],
 
   props: {
     width: {
@@ -17,9 +20,9 @@ export default {
       required: true,
       type: Number,
     },
-    eigenvalues: {
+    id: {
       required: true,
-      type: Array,
+      type: String,
     },
   },
 
@@ -43,7 +46,7 @@ vis-tile(title="PCA Scree Plot")
   scree-plot(
       :width="width",
       :height="height",
-      :eigenvalues="eigenvalues",
+      :eigenvalues="plot.data.s",
       :num-components="numComponents",
       :show-cutoffs="showCutoffs")
   template(v-slot:controls)

--- a/web/src/components/vis/VisTile.vue
+++ b/web/src/components/vis/VisTile.vue
@@ -5,6 +5,10 @@ export default {
       type: String,
       default: '',
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
@@ -17,18 +21,21 @@ export default {
 
 <template lang="pug">
 v-flex(shrink=1)
-  .white.rounded
+  .white.rounded.relative
     v-toolbar.primary.darken-3.top-rounded(dark, flat, dense)
       v-toolbar-title {{ title }}
       v-spacer
       v-toolbar-items(v-if="hasControls")
         slot(name="controls")
-
-    v-card.rounded(flat)
+    v-progress-linear.ma-0.progress(v-if="loading", indeterminate, height=4)
+    v-card.bottom-rounded(flat)
       slot
 </template>
 
 <style scoped lang="scss">
+.relative {
+  position: relative;
+}
 .rounded {
   border-radius: 5px;
 }
@@ -37,10 +44,18 @@ v-flex(shrink=1)
   border-radius: 5px 5px 0 0;
 }
 
+.bottom-rounded {
+  border-radius: 0 0 5px 5px;
+}
+
 .vis-tile {
   width: 600px;
   max-width: 600px;
   height: 648px;
   max-height: 648px;
+}
+
+.progress {
+  position: absolute;
 }
 </style>

--- a/web/src/store/mutations.type.js
+++ b/web/src/store/mutations.type.js
@@ -1,9 +1,9 @@
-export const REFRESH_PLOT = 'refresh_plot';
 export const REMOVE_DATASET = 'remove_dataset';
 export const SET_DATASET = 'set_dataset';
 export const SET_LABELS = 'set_labels';
 export const SET_LAST_ERROR = 'set_last_error';
 export const SET_LOADING = 'set_loading';
+export const SET_PLOT = 'set_plot';
 export const SET_SELECTION = 'set_selection';
 export const SET_SOURCE_DATA = 'set_source_data';
 export const SET_SESSION_STORE = 'set_session_store';

--- a/web/src/utils/mixins.js
+++ b/web/src/utils/mixins.js
@@ -1,4 +1,6 @@
+import { mapState, mapActions } from 'vuex';
 import { load_dataset } from '../store';
+import { LOAD_PLOT } from '../store/actions.type';
 
 /**
  * Load dataset from server for any view where
@@ -24,6 +26,48 @@ const loadDataset = {
   },
 };
 
+/**
+ * Expects `id` to exist on the wrapping component
+ * @param {String} plotName name of the plot to subscribe to
+ */
+const plotDataMixin = plotName => ({
+  data() {
+    return {
+      active: true,
+    };
+  },
+  activated() { this.active = true; },
+  deactivated() { this.active = false; },
+  mounted() { this.reloadPlot(); },
+  computed: {
+    ...mapState(['loading']),
+    dataset() { return this.$store.getters.dataset(this.id); },
+    plot() { return this.$store.getters.plot(this.id, plotName); },
+  },
+  watch: {
+    // eslint-disable-next-line func-names
+    'plot.valid': function () { this.reloadPlot(); },
+    id() { this.reloadPlot(); },
+    active(val) {
+      if (val) {
+        this.reloadPlot();
+      }
+    },
+  },
+  methods: {
+    ...mapActions({ loadPlot: LOAD_PLOT }),
+    reloadPlot() {
+      if (!this.plot.valid && this.active) {
+        this.loadPlot({
+          dataset_id: this.id,
+          name: plotName,
+        });
+      }
+    },
+  },
+});
+
 export {
   loadDataset,
+  plotDataMixin,
 };


### PR DESCRIPTION
This PR moves the logic for reloading plot data into a mixin that should be attached to some component container for the actual visualization element.

You can access the plot's always-up-to-data data by `plot.data`, and the only requirement is the presence of `id` as a property.

Still working on this, need to fix the validation flow.