### PR TITLE
Update base docker image

### DIFF
--- a/devops/base_image/Dockerfile
+++ b/devops/base_image/Dockerfile
@@ -16,19 +16,19 @@ RUN apt-get install libcairo2-dev libxt-dev -y
 RUN R -e 'install.packages("XML");' && \
     R -e 'install.packages("plotly");' && \
     R -e 'install.packages("BiocManager");' && \
-    R -e 'BiocManager::install("genefilter", version = "3.8")' && \
-    R -e 'BiocManager::install("GlobalAncova", version = "3.8")' && \
-    R -e 'BiocManager::install("impute", version = "3.8")' && \
-    R -e 'BiocManager::install("KEGGgraph", version = "3.8")' && \
-    R -e 'BiocManager::install("limma", version = "3.8")' && \
-    R -e 'BiocManager::install("pcaMethods", version = "3.8")' && \
-    R -e 'BiocManager::install("preprocessCore", version = "3.8")' && \
-    R -e 'BiocManager::install("Rgraphviz", version = "3.8")' && \
-    R -e 'BiocManager::install("siggenes", version = "3.8")' && \
-    R -e 'BiocManager::install("SSPA", version = "3.8")' && \
-    R -e 'BiocManager::install("sva", version = "3.8")'
+    R -e 'BiocManager::install("genefilter", version = "3.9")' && \
+    R -e 'BiocManager::install("GlobalAncova", version = "3.9")' && \
+    R -e 'BiocManager::install("impute", version = "3.9")' && \
+    R -e 'BiocManager::install("KEGGgraph", version = "3.9")' && \
+    R -e 'BiocManager::install("limma", version = "3.9")' && \
+    R -e 'BiocManager::install("pcaMethods", version = "3.9")' && \
+    R -e 'BiocManager::install("preprocessCore", version = "3.9")' && \
+    R -e 'BiocManager::install("Rgraphviz", version = "3.9")' && \
+    R -e 'BiocManager::install("siggenes", version = "3.9")' && \
+    R -e 'BiocManager::install("SSPA", version = "3.9")' && \
+    R -e 'BiocManager::install("sva", version = "3.9")'
 
-RUN R -e 'install.packages("devtools"); library(devtools); devtools::install_github("xia-lab/MetaboAnalystR")'
+RUN R -e 'install.packages("devtools"); library(devtools)'
 RUN R -e 'library(devtools); devtools::install_github("klutometis/roxygen")'
-RUN R -e 'BiocManager::install("impute", version = "3.8")'
+RUN R -e 'BiocManager::install("impute", version = "3.9")'
 RUN R -e 'install.packages("missForest")'


### PR DESCRIPTION
I already pushed this change to dockerhub, this will trigger a redeploy.

I'm hoping this will fix the bug that keeps reoccuring on the production
instance:
```
    unable to load shared object '/usr/lib/opencpu/library/curl/libs/curl.so':
      /usr/lib/x86_64-linux-gnu/libssl.so.1.1: version `OPENSSL_1_1_1' not found (required by /usr/lib/x86_64-linux-gnu/libcurl.so.4)

    In call:
    dyn.load(file, DLLpath = DLLpath, ...)
```
This updates to R 3.6.1 which is incompatible with some of the
requirements for metaboanalyst.  Because we aren't using that package, I
just removed it.  I'm sure we could remove most of the packages we are
installing, but it isn't worth sorting through them at this point.